### PR TITLE
Adds statement terminator to end of ALTER COLUMN default statements

### DIFF
--- a/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
@@ -312,12 +312,12 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             else
                 builder.Append("DROP DEFAULT");
 
+            // Terminate the DEFAULT above
+            builder.AppendLine(Dependencies.SqlGenerationHelper.StatementTerminator);
+
             // ALTER SEQUENCE
             if (sequenceName != null)
             {
-                // Terminate the DEFAULT above
-                builder.AppendLine(Dependencies.SqlGenerationHelper.StatementTerminator);
-
                 builder
                     .Append("ALTER SEQUENCE ")
                     .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(sequenceName))
@@ -333,8 +333,6 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
             if (oldComment != newComment)
             {
-                builder.AppendLine(Dependencies.SqlGenerationHelper.StatementTerminator);
-
                 builder
                     .Append("COMMENT ON COLUMN ")
                     .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Table, operation.Schema))

--- a/test/EFCore.PG.FunctionalTests/NpgsqlMigrationSqlGeneratorTest.cs
+++ b/test/EFCore.PG.FunctionalTests/NpgsqlMigrationSqlGeneratorTest.cs
@@ -281,7 +281,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.FunctionalTests
             Assert.Equal(
                 @"ALTER TABLE ""dbo"".""People"" ALTER COLUMN ""LuckyNumber"" TYPE int;" + EOL +
                 @"ALTER TABLE ""dbo"".""People"" ALTER COLUMN ""LuckyNumber"" SET NOT NULL;" + EOL +
-                @"ALTER TABLE ""dbo"".""People"" ALTER COLUMN ""LuckyNumber"" SET DEFAULT 7",
+                @"ALTER TABLE ""dbo"".""People"" ALTER COLUMN ""LuckyNumber"" SET DEFAULT 7;" + EOL,
             Sql);
         }
 
@@ -292,7 +292,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.FunctionalTests
             Assert.Equal(
                 @"ALTER TABLE ""People"" ALTER COLUMN ""LuckyNumber"" TYPE int4;" + EOL +
                 @"ALTER TABLE ""People"" ALTER COLUMN ""LuckyNumber"" SET NOT NULL;" + EOL +
-                @"ALTER TABLE ""People"" ALTER COLUMN ""LuckyNumber"" DROP DEFAULT",
+                @"ALTER TABLE ""People"" ALTER COLUMN ""LuckyNumber"" DROP DEFAULT;" + EOL,
             Sql);
         }
 
@@ -454,7 +454,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.FunctionalTests
             Assert.Equal(
                 "ALTER TABLE \"People\" ALTER COLUMN \"Name\" TYPE varchar(30);" + EOL +
                 "ALTER TABLE \"People\" ALTER COLUMN \"Name\" SET NOT NULL;" + EOL +
-                "ALTER TABLE \"People\" ALTER COLUMN \"Name\" DROP DEFAULT",
+                "ALTER TABLE \"People\" ALTER COLUMN \"Name\" DROP DEFAULT;" + EOL,
                 Sql);
         }
 


### PR DESCRIPTION
The script output from migrations was causing errors due to alter column not being properly terminated.