### PR TITLE
Fix for "Npgsql.PostgresException (0x80004005): 42601: syntax error at or near "00"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.userprefs
 /*.nupkg
 .nuget/
+.vs/
 [Bb]in/
 [Bb]uild/
 [Oo]bj/

--- a/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlDateTimeOffsetTypeMapping.cs
+++ b/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlDateTimeOffsetTypeMapping.cs
@@ -1,0 +1,22 @@
+﻿using System.Data;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Storage.Internal
+{
+    public class NpgsqlDateTimeOffsetTypeMapping : DateTimeOffsetTypeMapping
+    {
+        private const string DateTimeOffsetFormatConst = "{0:yyyy-MM-ddTHH:mm:ss.fffzzz}";
+
+        public NpgsqlDateTimeOffsetTypeMapping(
+            [NotNull] string storeType,
+            [NotNull] DbType? dbType = System.Data.DbType.DateTimeOffset)
+            : base(storeType, dbType: dbType)
+        {
+        }
+
+        public override RelationalTypeMapping Clone(string storeType, int? size)
+            => new NpgsqlDateTimeOffsetTypeMapping(storeType, DbType);
+
+        protected override string SqlLiteralFormatString => "'" + DateTimeOffsetFormatConst + "'";
+    }
+}

--- a/src/EFCore.PG/Storage/Internal/NpgsqlEFTypeMapper.cs
+++ b/src/EFCore.PG/Storage/Internal/NpgsqlEFTypeMapper.cs
@@ -88,6 +88,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             _baseClrMappings[typeof(char)] = new CharTypeMapping("text", DbType.String);
             _baseClrMappings[typeof(DateTime)] = _storeTypeMappings["timestamp"] = new DateTimeTypeMapping("timestamp", DbType.DateTime);
             _storeTypeMappings["timestamptz"] = new DateTimeTypeMapping("timestamptz", DbType.DateTime);
+            _baseClrMappings[typeof(DateTimeOffset)] = _storeTypeMappings["timestamptz"] = new NpgsqlDateTimeOffsetTypeMapping("timestamptz", DbType.DateTimeOffset);
             _baseClrMappings[typeof(bool)] = _storeTypeMappings["bool"] = new NpgsqlBoolTypeMapping();
 
             _baseClrMappings[typeof(decimal)] = new DecimalTypeMapping("numeric", DbType.Decimal);

--- a/test/EFCore.PG.FunctionalTests/BuiltInDataTypesNpgsqlFixture.cs
+++ b/test/EFCore.PG.FunctionalTests/BuiltInDataTypesNpgsqlFixture.cs
@@ -134,6 +134,10 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.FunctionalTests
 
             modelBuilder.Entity<MappedDataTypes>().Property(e => e.Xid).HasColumnType("xid");
             modelBuilder.Entity<MappedNullableDataTypes>().Property(e => e.Xid).HasColumnType("xid");
+
+            // TimeTz
+            modelBuilder.Entity<MappedDataTypes>().Property(e => e.Timetz).HasColumnType("timetz");
+            modelBuilder.Entity<MappedNullableDataTypes>().Property(e => e.Timetz).HasColumnType("timetz");
         }
 
         private static void MapColumnTypes<TEntity>(ModelBuilder modelBuilder) where TEntity : class
@@ -197,10 +201,10 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.FunctionalTests
         public byte[] Bytea { get; set; }
 
         public DateTime Timestamp { get; set; }
-        //public DateTime Timestamptz { get; set; }
+        public DateTime Timestamptz { get; set; }
         public DateTime Date { get; set; }
         public TimeSpan Time { get; set; }
-        //public DateTimeOffset Timetz { get; set; }
+        public DateTimeOffset Timetz { get; set; }
         public TimeSpan Interval { get; set; }
 
         public Guid Uuid { get; set; }

--- a/test/EFCore.PG.FunctionalTests/BuiltInDataTypesNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/BuiltInDataTypesNpgsqlTest.cs
@@ -36,10 +36,10 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.FunctionalTests
                         Bytea = new byte[] { 86 },
 
                         Timestamp = new DateTime(2015, 1, 2, 10, 11, 12),
-                        //Timestamptz = new DateTime(2016, 1, 2, 11, 11, 12, DateTimeKind.Utc),
+                        Timestamptz = new DateTime(2016, 1, 2, 11, 11, 12, DateTimeKind.Utc),
                         Date = new DateTime(2015, 1, 2, 0, 0, 0),
                         Time = new TimeSpan(11, 15, 12),
-                        //Timetz = new DateTimeOffset(0, 0, 0, 12, 0, 0, TimeSpan.FromHours(2)),
+                        Timetz = new DateTimeOffset(1, 1, 1, 12, 0, 0, TimeSpan.FromHours(2)),
                         Interval = new TimeSpan(11, 15, 12),
 
                         Uuid = new Guid("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"),
@@ -95,8 +95,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.FunctionalTests
                 DateTime? param10 = new DateTime(2015, 1, 2, 10, 11, 12);
                 Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.Timestamp == param10));
 
-                //DateTime? param11 = new DateTime(2019, 1, 2, 14, 11, 12, DateTimeKind.Utc);
-                //Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.Timestamptz == param11));
+                DateTime? param11 = new DateTime(2016, 1, 2, 11, 11, 12, DateTimeKind.Utc);
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.Timestamptz == param11));
 
                 DateTime? param12 = new DateTime(2015, 1, 2, 0, 0, 0);
                 Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.Date == param12));
@@ -104,8 +104,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.FunctionalTests
                 TimeSpan? param13 = new TimeSpan(11, 15, 12);
                 Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.Time == param13));
 
-                //DateTimeOffset? param14 = new DateTimeOffset(0, 0, 0, 12, 0, 0, TimeSpan.FromHours(2));
-                //Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.Timetz == param14));
+                DateTimeOffset? param14 = new DateTimeOffset(1, 1, 1, 12, 0, 0, TimeSpan.FromHours(2));
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.Timetz == param14));
 
                 TimeSpan? param15 = new TimeSpan(11, 15, 12);
                 Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.Interval == param15));
@@ -259,10 +259,10 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.FunctionalTests
                         Bytea = new byte[] { 86 },
 
                         Timestamp = new DateTime(2016, 1, 2, 11, 11, 12),
-                        //Timestamptz = new DateTime(2016, 1, 2, 11, 11, 12, DateTimeKind.Utc),
+                        Timestamptz = new DateTime(2016, 1, 2, 11, 11, 12, DateTimeKind.Utc),
                         Date = new DateTime(2015, 1, 2, 10, 11, 12),
                         Time = new TimeSpan(11, 15, 12),
-                        //Timetz = new DateTimeOffset(0, 0, 0, 12, 0, 0, TimeSpan.FromHours(2)),
+                        Timetz = new DateTimeOffset(1, 1, 1, 12, 0, 0, TimeSpan.FromHours(2)),
                         Interval = new TimeSpan(11, 15, 12),
 
                         Uuid = new Guid("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"),
@@ -301,10 +301,10 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.FunctionalTests
                 Assert.Equal(new byte[] { 86 }, entity.Bytea);
 
                 Assert.Equal(new DateTime(2016, 1, 2, 11, 11, 12), entity.Timestamp);
-                //Assert.Equal(new DateTime(2016, 1, 2, 11, 11, 12), entity.Timestamptz);
+                Assert.Equal(new DateTime(2016, 1, 2, 11, 11, 12), entity.Timestamptz);
                 Assert.Equal(new DateTime(2015, 1, 2, 0, 0, 0), entity.Date);
                 Assert.Equal(new TimeSpan(11, 15, 12), entity.Time);
-                //Assert.Equal(new DateTimeOffset(0, 0, 0, 12, 0, 0, TimeSpan.FromHours(2)), entity.Timetz);
+                Assert.Equal(new DateTimeOffset(1, 1, 1, 12, 0, 0, TimeSpan.FromHours(2)), entity.Timetz);
                 Assert.Equal(new TimeSpan(11, 15, 12), entity.Interval);
 
                 Assert.Equal(new Guid("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"), entity.Uuid);
@@ -343,10 +343,10 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.FunctionalTests
                         Bytea = new byte[] { 86 },
 
                         Timestamp = new DateTime(2016, 1, 2, 11, 11, 12),
-                        //Timestamptz = new DateTime(2016, 1, 2, 11, 11, 12, DateTimeKind.Utc),
+                        Timestamptz = new DateTime(2016, 1, 2, 11, 11, 12, DateTimeKind.Utc),
                         Date = new DateTime(2015, 1, 2, 10, 11, 12),
                         Time = new TimeSpan(11, 15, 12),
-                        //Timetz = new DateTimeOffset(0, 0, 0, 12, 0, 0, TimeSpan.FromHours(2)),
+                        Timetz = new DateTimeOffset(1, 1, 1, 12, 0, 0, TimeSpan.FromHours(2)),
                         Interval = new TimeSpan(11, 15, 12),
 
                         Uuid = new Guid("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"),
@@ -383,10 +383,10 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.FunctionalTests
                 Assert.Equal(new byte[] { 86 }, entity.Bytea);
 
                 Assert.Equal(new DateTime(2016, 1, 2, 11, 11, 12), entity.Timestamp);
-                //Assert.Equal(new DateTime(2016, 1, 2, 11, 11, 12), entity.Timestamptz);
+                Assert.Equal(new DateTime(2016, 1, 2, 11, 11, 12), entity.Timestamptz);
                 Assert.Equal(new DateTime(2015, 1, 2, 0, 0, 0), entity.Date);
                 Assert.Equal(new TimeSpan(11, 15, 12), entity.Time);
-                //Assert.Equal(new DateTimeOffset(0, 0, 0, 12, 0, 0, TimeSpan.FromHours(2)), entity.Timetz);
+                Assert.Equal(new DateTimeOffset(1, 1, 1, 12, 0, 0, TimeSpan.FromHours(2)), entity.Timetz);
                 Assert.Equal(new TimeSpan(11, 15, 12), entity.Interval);
 
                 Assert.Equal(new Guid("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"), entity.Uuid);


### PR DESCRIPTION
When submitting a DateTimeOffset value as a query parameter, we were getting the exception "Npgsql.PostgresException (0x80004005): 42601: syntax error at or near "00".  These modifications fix that problem and, to some extent, I think address the open issue "Support for timestamptz and timetz".



