### PR TITLE
Full text search follow up

### DIFF
--- a/src/EFCore.PG/FullTextSearch/NpgsqlFullTextSearchDbFunctionsExtensions.cs
+++ b/src/EFCore.PG/FullTextSearch/NpgsqlFullTextSearchDbFunctionsExtensions.cs
@@ -32,6 +32,13 @@ namespace Microsoft.EntityFrameworkCore
     public static class NpgsqlFullTextSearchDbFunctionsExtensions
     {
         /// <summary>
+        /// Convert <paramref name="lexemes" /> to a tsvector.
+        /// https://www.postgresql.org/docs/current/static/functions-textsearch.html
+        /// </summary>
+        public static NpgsqlTsVector ArrayToTsVector(this DbFunctions _, string[] lexemes) =>
+            throw new NotSupportedException();
+
+        /// <summary>
         /// Reduce <paramref name="document" /> to tsvector.
         /// http://www.postgresql.org/docs/current/static/textsearch-controls.html#TEXTSEARCH-PARSING-DOCUMENTS
         /// </summary>

--- a/src/EFCore.PG/FullTextSearch/NpgsqlFullTextSearchLinqExtensions.cs
+++ b/src/EFCore.PG/FullTextSearch/NpgsqlFullTextSearchLinqExtensions.cs
@@ -189,6 +189,20 @@ namespace Microsoft.EntityFrameworkCore
             throw new NotSupportedException();
 
         /// <summary>
+        /// Return a new vector with <paramref name="lexeme" /> removed from <paramref name="vector" />
+        /// https://www.postgresql.org/docs/current/static/functions-textsearch.html
+        /// </summary>
+        public static NpgsqlTsVector Delete(this NpgsqlTsVector vector, string lexeme) =>
+            throw new NotSupportedException();
+
+        /// <summary>
+        /// Return a new vector with <paramref name="lexemes" /> removed from <paramref name="vector" />
+        /// https://www.postgresql.org/docs/current/static/functions-textsearch.html
+        /// </summary>
+        public static NpgsqlTsVector Delete(this NpgsqlTsVector vector, string[] lexemes) =>
+            throw new NotSupportedException();
+
+        /// <summary>
         /// Returns the number of lexemes in <paramref name="vector" />.
         /// http://www.postgresql.org/docs/current/static/textsearch-features.html#TEXTSEARCH-MANIPULATE-TSVECTOR
         /// </summary>

--- a/src/EFCore.PG/FullTextSearch/NpgsqlFullTextSearchLinqExtensions.cs
+++ b/src/EFCore.PG/FullTextSearch/NpgsqlFullTextSearchLinqExtensions.cs
@@ -203,6 +203,13 @@ namespace Microsoft.EntityFrameworkCore
             throw new NotSupportedException();
 
         /// <summary>
+        /// Returns a new vector with only lexemes having weights specified in <paramref name="weights" />.
+        /// https://www.postgresql.org/docs/current/static/functions-textsearch.html
+        /// </summary>
+        public static NpgsqlTsVector Filter(this NpgsqlTsVector vector, char[] weights) =>
+            throw new NotSupportedException();
+
+        /// <summary>
         /// Returns the number of lexemes in <paramref name="vector" />.
         /// http://www.postgresql.org/docs/current/static/textsearch-features.html#TEXTSEARCH-MANIPULATE-TSVECTOR
         /// </summary>

--- a/src/EFCore.PG/FullTextSearch/NpgsqlFullTextSearchLinqExtensions.cs
+++ b/src/EFCore.PG/FullTextSearch/NpgsqlFullTextSearchLinqExtensions.cs
@@ -145,6 +145,15 @@ namespace Microsoft.EntityFrameworkCore
             throw new NotSupportedException();
 
         /// <summary>
+        /// Returns a vector which combines the lexemes and positional information of <paramref name="vector1" />
+        /// and <paramref name="vector2"/> using the || tsvector operator. Positions and weight labels are retained
+        /// during the concatenation.
+        /// https://www.postgresql.org/docs/10/static/textsearch-features.html#TEXTSEARCH-MANIPULATE-TSVECTOR
+        /// </summary>
+        public static NpgsqlTsVector Concat(this NpgsqlTsVector vector1, NpgsqlTsVector vector2) =>
+            throw new NotSupportedException();
+
+        /// <summary>
         /// Assign weight to each element of <paramref name="vector" /> and return a new
         /// weighted tsvector.
         /// http://www.postgresql.org/docs/current/static/textsearch-features.html#TEXTSEARCH-MANIPULATE-TSVECTOR

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlFullTextSearchMethodTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlFullTextSearchMethodTranslator.cs
@@ -201,6 +201,12 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Inte
                     methodCallExpression.Method.ReturnType,
                     arguments);
 
+            case nameof(NpgsqlFullTextSearchLinqExtensions.Delete):
+                return new SqlFunctionExpression(
+                    "ts_delete",
+                    methodCallExpression.Method.ReturnType,
+                    methodCallExpression.Arguments);
+
             case nameof(NpgsqlFullTextSearchLinqExtensions.GetLength):
                 return new SqlFunctionExpression(
                     "length",

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlFullTextSearchMethodTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlFullTextSearchMethodTranslator.cs
@@ -207,6 +207,16 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Inte
                     methodCallExpression.Method.ReturnType,
                     methodCallExpression.Arguments);
 
+            case nameof(NpgsqlFullTextSearchLinqExtensions.Filter):
+                return new SqlFunctionExpression(
+                    "ts_filter",
+                    methodCallExpression.Method.ReturnType,
+                    new[]
+                    {
+                        methodCallExpression.Arguments[0],
+                        new ExplicitStoreTypeCastExpression(methodCallExpression.Arguments[1], typeof(char[]), "\"char\"[]")
+                    });
+
             case nameof(NpgsqlFullTextSearchLinqExtensions.GetLength):
                 return new SqlFunctionExpression(
                     "length",

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlFullTextSearchMethodTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlFullTextSearchMethodTranslator.cs
@@ -47,6 +47,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Inte
         static readonly IReadOnlyDictionary<string, string> _sqlNameByMethodName =
             new Dictionary<string, string>
             {
+                [nameof(NpgsqlFullTextSearchDbFunctionsExtensions.ArrayToTsVector)] = "array_to_tsvector",
                 [nameof(NpgsqlFullTextSearchDbFunctionsExtensions.ToTsVector)] = "to_tsvector",
                 [nameof(NpgsqlFullTextSearchDbFunctionsExtensions.PlainToTsQuery)] = "plainto_tsquery",
                 [nameof(NpgsqlFullTextSearchDbFunctionsExtensions.PhraseToTsQuery)] = "phraseto_tsquery",

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlFullTextSearchMethodTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlFullTextSearchMethodTranslator.cs
@@ -105,6 +105,11 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Inte
                     methodCallExpression.Arguments[0],
                     methodCallExpression.Arguments[1]);
 
+            case nameof(NpgsqlFullTextSearchLinqExtensions.Concat):
+                return FullTextSearchExpression.TsVectorConcat(
+                    methodCallExpression.Arguments[0],
+                    methodCallExpression.Arguments[1]);
+
             default:
                 return null;
             }

--- a/src/EFCore.PG/Query/Expressions/Internal/FullTextSearchExpression.cs
+++ b/src/EFCore.PG/Query/Expressions/Internal/FullTextSearchExpression.cs
@@ -92,6 +92,12 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.Expressions.Internal
             return new FullTextSearchExpression("@@", left, right, typeof(bool));
         }
 
+        public static FullTextSearchExpression TsVectorConcat([NotNull] Expression left, [NotNull] Expression right)
+        {
+            ValidateArguments(left, typeof(NpgsqlTsVector), right, typeof(NpgsqlTsVector));
+            return new FullTextSearchExpression("||", left, right, typeof(NpgsqlTsVector));
+        }
+
         private static void ValidateArguments(
             [NotNull] Expression left,
             [NotNull] Type validLeftType,

--- a/test/EFCore.PG.FunctionalTests/Query/FullTextSearchDbFunctionsNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/FullTextSearchDbFunctionsNpgsqlTest.cs
@@ -549,6 +549,23 @@ LIMIT 1");
         }
 
         [Fact]
+        public void Filter()
+        {
+            using (var context = CreateContext())
+            {
+                var tsVector = context.Customers
+                    .Select(c => NpgsqlTsVector.Parse("b:1A c:2B d:3C").Filter(new[] { 'B', 'C' }))
+                    .First();
+                Assert.Equal(NpgsqlTsVector.Parse("c:2B d:3C").ToString(), tsVector.ToString());
+            }
+
+            AssertSql(
+                @"SELECT ts_filter(CAST('b:1A c:2B d:3C' AS tsvector), CAST(ARRAY['B','C'] AS ""char""[]))
+FROM ""Customers"" AS c
+LIMIT 1");
+        }
+
+        [Fact]
         public void GetLength()
         {
             using (var context = CreateContext())

--- a/test/EFCore.PG.FunctionalTests/Query/FullTextSearchDbFunctionsNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/FullTextSearchDbFunctionsNpgsqlTest.cs
@@ -515,6 +515,40 @@ LIMIT 1");
         }
 
         [Fact]
+        public void Delete_With_Single_Lexeme()
+        {
+            using (var context = CreateContext())
+            {
+                var tsVector = context.Customers
+                    .Select(c => EF.Functions.ToTsVector("b c").Delete("c"))
+                    .First();
+                Assert.Equal(NpgsqlTsVector.Parse("b:1").ToString(), tsVector.ToString());
+            }
+
+            AssertSql(
+                @"SELECT ts_delete(to_tsvector('b c'), 'c')
+FROM ""Customers"" AS c
+LIMIT 1");
+        }
+
+        [Fact]
+        public void Delete_With_Multiple_Lexemes()
+        {
+            using (var context = CreateContext())
+            {
+                var tsVector = context.Customers
+                    .Select(c => EF.Functions.ToTsVector("b c d").Delete(new[] { "c", "d" }))
+                    .First();
+                Assert.Equal(NpgsqlTsVector.Parse("b:1").ToString(), tsVector.ToString());
+            }
+
+            AssertSql(
+                @"SELECT ts_delete(to_tsvector('b c d'), ARRAY['c','d'])
+FROM ""Customers"" AS c
+LIMIT 1");
+        }
+
+        [Fact]
         public void GetLength()
         {
             using (var context = CreateContext())

--- a/test/EFCore.PG.FunctionalTests/Query/FullTextSearchDbFunctionsNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/FullTextSearchDbFunctionsNpgsqlTest.cs
@@ -430,6 +430,23 @@ LIMIT 1");
         }
 
         [Fact]
+        public void TsVectorConcat()
+        {
+            using (var context = CreateContext())
+            {
+                var tsVector = context.Customers
+                    .Select(c => EF.Functions.ToTsVector("b").Concat(EF.Functions.ToTsVector("c")))
+                    .First();
+                Assert.Equal(NpgsqlTsVector.Parse("b:1 c:2").ToString(), tsVector.ToString());
+            }
+
+            AssertSql(
+                @"SELECT (to_tsvector('b') || to_tsvector('c'))
+FROM ""Customers"" AS c
+LIMIT 1");
+        }
+
+        [Fact]
         public void Setweight_With_Enum()
         {
             using (var context = CreateContext())


### PR DESCRIPTION
@roji This is a follow up to #315 that implements a few missing methods and operators for full text search and resolves issue #373:

1. tsvector concat operator (Concat extension method on NpgsqlTsVector)
2. ts_delete function (single lexeme and array of lexemes overload).
3. ts_filter function
4. array_to_tsvector function.

There is a caveat however, due to limitations in EF Core, all functions that take array parameters can only accept constant values (ie: the array must be computable outside the query). Attempts to use an array with elements that come from range variables from tables will result in NotSupportedException being thrown from deep within EF Core itself.