### PR TITLE
Bug fix for #323

### DIFF
--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlRangeTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlRangeTranslator.cs
@@ -42,6 +42,11 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Inte
         [CanBeNull]
         public Expression Translate(MethodCallExpression expression)
         {
+            if (expression.Method.DeclaringType != typeof(NpgsqlRangeExtensions))
+            {
+                return null;
+            }
+
             switch (expression.Method.Name)
             {
             case nameof(NpgsqlRangeExtensions.Contains):

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlRangeTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlRangeTranslator.cs
@@ -43,9 +43,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Inte
         public Expression Translate(MethodCallExpression expression)
         {
             if (expression.Method.DeclaringType != typeof(NpgsqlRangeExtensions))
-            {
                 return null;
-            }
 
             switch (expression.Method.Name)
             {


### PR DESCRIPTION
The `NpgsqlRangeTranslator` merged in #323 uses nameof(...) without checking the declaring type. This returns the unqualified name, such that all methods named `Contains` (for example) that reach this translator are translated to the range operator.

This commit adds a check to screen for the declaring type.