### PR TITLE
Add ClientEvaluationNotSupportedException

### DIFF
--- a/src/EFCore.PG/ClientEvaluationNotSupported.cs
+++ b/src/EFCore.PG/ClientEvaluationNotSupported.cs
@@ -1,0 +1,41 @@
+﻿#region License
+
+// The PostgreSQL License
+//
+// Copyright (C) 2016 The Npgsql Development Team
+//
+// Permission to use, copy, modify, and distribute this software and its
+// documentation for any purpose, without fee, and without a written
+// agreement is hereby granted, provided that the above copyright notice
+// and this paragraph and the following two paragraphs appear in all copies.
+//
+// IN NO EVENT SHALL THE NPGSQL DEVELOPMENT TEAM BE LIABLE TO ANY PARTY
+// FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES,
+// INCLUDING LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS
+// DOCUMENTATION, EVEN IF THE NPGSQL DEVELOPMENT TEAM HAS BEEN ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//
+// THE NPGSQL DEVELOPMENT TEAM SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS
+// ON AN "AS IS" BASIS, AND THE NPGSQL DEVELOPMENT TEAM HAS NO OBLIGATIONS
+// TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+
+#endregion
+
+using System;
+using System.Runtime.CompilerServices;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Internal;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL
+{
+    /// <summary>
+    /// An exception that is thrown when a method intended for SQL translation by EF Core is evaluated by the client.
+    /// </summary>
+    public class ClientEvaluationNotSupportedException : NotSupportedException
+    {
+        /// <inheritdoc />
+        public ClientEvaluationNotSupportedException([CallerMemberName] string method = default)
+            : base(NpgsqlStrings.ClientEvaluation(method)) {}
+    }
+}

--- a/src/EFCore.PG/Properties/NpgsqlStrings.Designer.cs
+++ b/src/EFCore.PG/Properties/NpgsqlStrings.Designer.cs
@@ -308,6 +308,14 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Internal
                     NpgsqlEventId.ExpressionIndexSkippedWarning,
                     _resourceManager.GetString("LogExpressionIndexSkipped")));
 
+        /// <summary>
+
+        ///     '{callerMemberName}' is only intended for SQL translation by EF Core, but was evaluated by the client.
+
+        /// </summary>
+
+        public static string ClientEvaluation([CanBeNull] object callerMemberName)
+            => string.Format(GetString("ClientEvaluation", nameof(callerMemberName)), callerMemberName);
 
         private static string GetString(string name, params string[] formatterNames)
         {

--- a/src/EFCore.PG/Properties/NpgsqlStrings.resx
+++ b/src/EFCore.PG/Properties/NpgsqlStrings.resx
@@ -187,4 +187,7 @@
     <value>Expression index '{name}' on table {tableName} cannot be scaffolded, expression indices aren't supported and must be added via raw SQL in migrations.</value>
     <comment>Warning NpgsqlEventId.ExpressionIndexSkippedWarning string string</comment>
   </data>
+  <data name="ClientEvaluation" xml:space="preserve">
+    <value>'{callerMemberName}' is only intended for SQL translation by EF Core, but was evaluated by the client.</value>
+  </data>
 </root>


### PR DESCRIPTION
`ClientEvaluationNotSupportedException` originated in #407 to make it clear that certain functions would always throw if evaluated on the client.

I opened https://github.com/aspnet/EntityFrameworkCore/pull/12515 to [see](https://github.com/npgsql/Npgsql.EntityFrameworkCore.PostgreSQL/pull/407#discussion_r191078236) if it would be a good fit for the main EF Core project. Based on feedback to that PR, it looks like this exception doesn't meet the criteria for inclusion in the main project.

I'm opening this PR to see if we still want to include this exception, or if we should just throw the `NotSupportedException` with a message from the resource manager.

/cc @roji 