### PR TITLE
Add support to parse IP and MAC addresses

### DIFF
--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlNetworkTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlNetworkTranslator.cs
@@ -46,11 +46,21 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Inte
         [CanBeNull]
         public Expression Translate(MethodCallExpression expression)
         {
-            if (expression.Method.DeclaringType != typeof(NpgsqlNetworkExtensions))
+            var declaringType = expression.Method.DeclaringType;
+
+            if (declaringType != typeof(NpgsqlNetworkExtensions) &&
+                declaringType != typeof(IPAddress) &&
+                declaringType != typeof(PhysicalAddress))
                 return null;
 
             switch (expression.Method.Name)
             {
+            case nameof(IPAddress.Parse) when declaringType == typeof(IPAddress):
+                return new ExplicitCastExpression(expression.Arguments[0], typeof(IPAddress));
+
+            case nameof(PhysicalAddress.Parse) when declaringType == typeof(PhysicalAddress):
+                return new ExplicitCastExpression(expression.Arguments[0], typeof(PhysicalAddress));
+
             case nameof(NpgsqlNetworkExtensions.LessThan):
                 return new CustomBinaryExpression(expression.Arguments[1], expression.Arguments[2], "<", typeof(bool));
 

--- a/src/EFCore.PG/Query/Internal/NpgsqlEvaluatableExpressionFilter.cs
+++ b/src/EFCore.PG/Query/Internal/NpgsqlEvaluatableExpressionFilter.cs
@@ -1,31 +1,4 @@
-﻿#region License
-
-// The PostgreSQL License
-//
-// Copyright (C) 2016 The Npgsql Development Team
-//
-// Permission to use, copy, modify, and distribute this software and its
-// documentation for any purpose, without fee, and without a written
-// agreement is hereby granted, provided that the above copyright notice
-// and this paragraph and the following two paragraphs appear in all copies.
-//
-// IN NO EVENT SHALL THE NPGSQL DEVELOPMENT TEAM BE LIABLE TO ANY PARTY
-// FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES,
-// INCLUDING LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS
-// DOCUMENTATION, EVEN IF THE NPGSQL DEVELOPMENT TEAM HAS BEEN ADVISED OF
-// THE POSSIBILITY OF SUCH DAMAGE.
-//
-// THE NPGSQL DEVELOPMENT TEAM SPECIFICALLY DISCLAIMS ANY WARRANTIES,
-// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-// AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS
-// ON AN "AS IS" BASIS, AND THE NPGSQL DEVELOPMENT TEAM HAS NO OBLIGATIONS
-// TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-
-#endregion
-
-using System.Linq.Expressions;
-using System.Net;
-using System.Net.NetworkInformation;
+﻿using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
@@ -37,46 +10,23 @@ using NpgsqlTypes;
 // this (we're currently replacing an internal service
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.Internal
 {
-    /// <summary>
-    /// Represents an Npgsql-specific filter to identify methods that are evaluatable.
-    /// </summary>
     public class NpgsqlEvaluatableExpressionFilter : RelationalEvaluatableExpressionFilter
     {
-        /// <summary>
-        /// The static method info for <see cref="IPAddress.Parse(string)"/>.
-        /// </summary>
-        [NotNull] static readonly MethodInfo IPAddressParse =
-            typeof(IPAddress).GetRuntimeMethod(nameof(IPAddress.Parse), new[] { typeof(string) });
+        static readonly MethodInfo _tsQueryParse = typeof(NpgsqlTsQuery).GetMethod(
+            nameof(NpgsqlTsQuery.Parse),
+            BindingFlags.Public | BindingFlags.Static);
 
-        /// <summary>
-        /// The static method info for <see cref="PhysicalAddress.Parse(string)"/>.
-        /// </summary>
-        [NotNull] static readonly MethodInfo PhysicalAddressParse =
-            typeof(PhysicalAddress).GetRuntimeMethod(nameof(PhysicalAddress.Parse), new[] { typeof(string) });
+        static readonly MethodInfo _tsVectorParse = typeof(NpgsqlTsVector).GetMethod(
+            nameof(NpgsqlTsVector.Parse),
+            BindingFlags.Public | BindingFlags.Static);
 
-        /// <summary>
-        /// The static method info for <see cref="NpgsqlTsQuery.Parse(string)"/>.
-        /// </summary>
-        [NotNull] static readonly MethodInfo TsQueryParse =
-            typeof(NpgsqlTsQuery).GetRuntimeMethod(nameof(NpgsqlTsQuery.Parse), new[] { typeof(string) });
+        public NpgsqlEvaluatableExpressionFilter([NotNull] IModel model) : base(model) { }
 
-        /// <summary>
-        /// The static method info for <see cref="NpgsqlTsVector.Parse(string)"/>.
-        /// </summary>
-        [NotNull] static readonly MethodInfo TsVectorParse =
-            typeof(NpgsqlTsVector).GetRuntimeMethod(nameof(NpgsqlTsVector.Parse), new[] { typeof(string) });
-
-        /// <inheritdoc />
-        public NpgsqlEvaluatableExpressionFilter([NotNull] IModel model) : base(model) {}
-
-        /// <inheritdoc />
-        public override bool IsEvaluatableMethodCall(MethodCallExpression methodCallExpression)
-            => methodCallExpression.Method != IPAddressParse &&
-               methodCallExpression.Method != PhysicalAddressParse &&
-               methodCallExpression.Method != TsQueryParse &&
-               methodCallExpression.Method != TsVectorParse &&
-               methodCallExpression.Method.DeclaringType != typeof(NpgsqlFullTextSearchDbFunctionsExtensions) &&
-               methodCallExpression.Method.DeclaringType != typeof(NpgsqlFullTextSearchLinqExtensions) &&
-               base.IsEvaluatableMethodCall(methodCallExpression);
+        public override bool IsEvaluatableMethodCall(MethodCallExpression methodCallExpression) =>
+            methodCallExpression.Method != _tsQueryParse
+            && methodCallExpression.Method != _tsVectorParse
+            && methodCallExpression.Method.DeclaringType != typeof(NpgsqlFullTextSearchDbFunctionsExtensions)
+            && methodCallExpression.Method.DeclaringType != typeof(NpgsqlFullTextSearchLinqExtensions)
+            && base.IsEvaluatableMethodCall(methodCallExpression);
     }
 }

--- a/test/EFCore.PG.FunctionalTests/Query/NetworkQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/NetworkQueryNpgsqlTest.cs
@@ -65,6 +65,118 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
 
         #endregion
 
+        #region ParseTests
+
+        /// <summary>
+        /// Tests translation for <see cref="IPAddress.Parse(string)"/>.
+        /// </summary>
+        [Fact]
+        public void IPAddress_inet_parse_column()
+        {
+            using (NetContext context = Fixture.CreateContext())
+            {
+                NetTestEntity[] _ =
+                    context.NetTestEntities
+                           .Where(x => x.Inet.Equals(IPAddress.Parse(x.TextInet)))
+                           .ToArray();
+
+                AssertContainsSql("WHERE x.\"Inet\" = CAST(x.\"TextInet\" AS inet)");
+            }
+        }
+
+        /// <summary>
+        /// Tests translation for <see cref="IPAddress.Parse(string)"/>.
+        /// </summary>
+        [Fact]
+        public void PhysicalAddress_macaddr_parse_column()
+        {
+            using (NetContext context = Fixture.CreateContext())
+            {
+                NetTestEntity[] _ =
+                    context.NetTestEntities
+                           .Where(x => x.Macaddr.Equals(PhysicalAddress.Parse(x.TextMacaddr)))
+                           .ToArray();
+
+                AssertContainsSql("WHERE x.\"Macaddr\" = CAST(x.\"TextMacaddr\" AS macaddr)");
+            }
+        }
+
+        /// <summary>
+        /// Tests translation for <see cref="IPAddress.Parse(string)"/>.
+        /// </summary>
+        [Fact]
+        public void IPAddress_inet_parse_literal()
+        {
+            using (NetContext context = Fixture.CreateContext())
+            {
+                NetTestEntity[] _ =
+                    context.NetTestEntities
+                           .Where(x => x.Inet.Equals(IPAddress.Parse("127.0.0.1")))
+                           .ToArray();
+
+                AssertContainsSql("WHERE x.\"Inet\" = CAST('127.0.0.1' AS inet)");
+            }
+        }
+
+        /// <summary>
+        /// Tests translation for <see cref="IPAddress.Parse(string)"/>.
+        /// </summary>
+        [Fact]
+        public void PhysicalAddress_macaddr_parse_literal()
+        {
+            using (NetContext context = Fixture.CreateContext())
+            {
+                NetTestEntity[] _ =
+                    context.NetTestEntities
+                           .Where(x => x.Macaddr.Equals(PhysicalAddress.Parse("12-34-56-00-00-00")))
+                           .ToArray();
+
+                AssertContainsSql("WHERE x.\"Macaddr\" = CAST('12-34-56-00-00-00' AS macaddr)");
+            }
+        }
+
+        /// <summary>
+        /// Tests translation for <see cref="IPAddress.Parse(string)"/>.
+        /// </summary>
+        [Fact]
+        public void IPAddress_inet_parse_parameter()
+        {
+            using (NetContext context = Fixture.CreateContext())
+            {
+                // ReSharper disable once ConvertToConstant.Local
+                var inet = "127.0.0.1";
+
+                NetTestEntity[] _ =
+                    context.NetTestEntities
+                           .Where(x => x.Inet.Equals(IPAddress.Parse(inet)))
+                           .ToArray();
+
+                AssertContainsSql("WHERE x.\"Inet\" = CAST(@__inet_0 AS inet)");
+            }
+        }
+
+        /// <summary>
+        /// Tests translation for <see cref="IPAddress.Parse(string)"/>.
+        /// </summary>
+        [Fact]
+        public void PhysicalAddress_macaddr_parse_parameter()
+        {
+            using (NetContext context = Fixture.CreateContext())
+            {
+                // ReSharper disable once ConvertToConstant.Local
+                var macaddr = "12-34-56-00-00-00";
+
+                NetTestEntity[] _ =
+                    context.NetTestEntities
+                           .Where(x => x.Macaddr.Equals(PhysicalAddress.Parse(macaddr)))
+                           .ToArray();
+
+                AssertContainsSql("WHERE x.\"Macaddr\" = CAST(@__macaddr_0 AS macaddr)");
+            }
+        }
+
+        #endregion
+
         #region RelationalOperatorTests
 
         /// <summary>
@@ -1580,6 +1692,16 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             /// </summary>
             [Column(TypeName = "macaddr8")]
             public PhysicalAddress Macaddr8 { get; set; }
+
+            /// <summary>
+            /// The text form of <see cref="Inet"/>.
+            /// </summary>
+            public string TextInet { get; set; }
+
+            /// <summary>
+            /// The text form of <see cref="Macaddr"/>.
+            /// </summary>
+            public string TextMacaddr { get; set; }
         }
 
         /// <summary>
@@ -1598,7 +1720,11 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             /// <param name="options">
             /// The options to be used for configuration.
             /// </param>
-            public NetContext(DbContextOptions options) : base(options) { }
+            public NetContext(DbContextOptions options) : base(options) {}
+
+            /// <inheritdoc />
+            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                => base.OnConfiguring(optionsBuilder.EnableSensitiveDataLogging());
         }
 
         #endregion

--- a/test/EFCore.PG.FunctionalTests/Query/NetworkQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/NetworkQueryNpgsqlTest.cs
@@ -114,7 +114,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
                            .Where(x => x.Inet.Equals(IPAddress.Parse("127.0.0.1")))
                            .ToArray();
 
-                AssertContainsSql("WHERE x.\"Inet\" = CAST('127.0.0.1' AS inet)");
+                AssertContainsSql("WHERE x.\"Inet\" = @__Parse_0");
             }
         }
 
@@ -131,7 +131,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
                            .Where(x => x.Macaddr.Equals(PhysicalAddress.Parse("12-34-56-00-00-00")))
                            .ToArray();
 
-                AssertContainsSql("WHERE x.\"Macaddr\" = CAST('12-34-56-00-00-00' AS macaddr)");
+                AssertContainsSql("WHERE x.\"Macaddr\" = @__Parse_0");
             }
         }
 
@@ -151,7 +151,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
                            .Where(x => x.Inet.Equals(IPAddress.Parse(inet)))
                            .ToArray();
 
-                AssertContainsSql("WHERE x.\"Inet\" = CAST(@__inet_0 AS inet)");
+                AssertContainsSql("WHERE x.\"Inet\" = @__Parse_0");
             }
         }
 
@@ -171,7 +171,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
                            .Where(x => x.Macaddr.Equals(PhysicalAddress.Parse(macaddr)))
                            .ToArray();
 
-                AssertContainsSql("WHERE x.\"Macaddr\" = CAST(@__macaddr_0 AS macaddr)");
+                AssertContainsSql("WHERE x.\"Macaddr\" = @__Parse_0");
             }
         }
 
@@ -1721,10 +1721,6 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             /// The options to be used for configuration.
             /// </param>
             public NetContext(DbContextOptions options) : base(options) {}
-
-            /// <inheritdoc />
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => base.OnConfiguring(optionsBuilder.EnableSensitiveDataLogging());
         }
 
         #endregion


### PR DESCRIPTION
- `IPAddress.Parse(string)`
- `PhysicalAddres.Parse(string)`

## Related
#534