### PR TITLE
Cleanup and refactor extension expressions

### DIFF
--- a/src/EFCore.PG/Query/Expressions/Internal/ArrayAnyAllExpression.cs
+++ b/src/EFCore.PG/Query/Expressions/Internal/ArrayAnyAllExpression.cs
@@ -93,23 +93,20 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.Expressions.Internal
 
         /// <inheritdoc />
         protected override Expression Accept(ExpressionVisitor visitor)
-            => visitor is NpgsqlQuerySqlGenerator npsgqlGenerator
-                ? npsgqlGenerator.VisitArrayAnyAll(this)
+            => visitor is NpgsqlQuerySqlGenerator npgsqlGenerator
+                ? npgsqlGenerator.VisitArrayAnyAll(this)
                 : base.Accept(visitor);
 
         /// <inheritdoc />
         protected override Expression VisitChildren(ExpressionVisitor visitor)
         {
-            if (!(visitor.Visit(Operand) is Expression operand))
-                throw new ArgumentException($"The {nameof(operand)} of a {nameof(ArrayAnyAllExpression)} cannot be null.");
-
-            if (!(visitor.Visit(Array) is Expression collection))
-                throw new ArgumentException($"The {nameof(collection)} of a {nameof(ArrayAnyAllExpression)} cannot be null.");
+            var operand = visitor.Visit(Operand) ?? Operand;
+            var array = visitor.Visit(Array) ?? Array;
 
             return
-                operand == Operand && collection == Array
-                    ? this
-                    : new ArrayAnyAllExpression(ArrayComparisonType, Operator, operand, collection);
+                operand != Operand || array != Array
+                    ? new ArrayAnyAllExpression(ArrayComparisonType, Operator, operand, array)
+                    : this;
         }
 
         /// <inheritdoc />
@@ -131,8 +128,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.Expressions.Internal
                          (397 * Array.GetHashCode()));
 
         /// <inheritdoc />
-        public override string ToString()
-            => $"{Operand} {Operator} {ArrayComparisonType.ToString()} ({Array})";
+        public override string ToString() => $"{Operand} {Operator} {ArrayComparisonType.ToString()} ({Array})";
     }
 
     /// <summary>

--- a/src/EFCore.PG/Query/Expressions/Internal/CustomUnaryExpression.cs
+++ b/src/EFCore.PG/Query/Expressions/Internal/CustomUnaryExpression.cs
@@ -1,10 +1,8 @@
 ﻿using System;
-using System.Linq;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Query.Sql.Internal;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Utilities;
-using NpgsqlTypes;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.Expressions.Internal
 {
@@ -14,49 +12,67 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.Expressions.Internal
     /// </summary>
     public class CustomUnaryExpression : Expression
     {
+        /// <inheritdoc />
+        public override ExpressionType NodeType => ExpressionType.Extension;
+
+        /// <inheritdoc />
+        public override Type Type { get; }
+
+        /// <summary>
+        /// The expression acted on by the operator.
+        /// </summary>
+        [NotNull]
+        public Expression Operand { get; }
+
+        /// <summary>
+        /// The operator.
+        /// </summary>
+        [NotNull]
+        public string Operator { get; }
+
+        /// <summary>
+        /// True if the operator follows the operand; otherwise, false.
+        /// </summary>
+        public bool Postfix { get; }
+
+        /// <summary>
+        /// Constructs a <see cref="CustomUnaryExpression"/>.
+        /// </summary>
+        /// <param name="operand">The expression acted on by the <paramref name="unaryOperator"/>.</param>
+        /// <param name="unaryOperator">The operator symbol acting on the expression.</param>
+        /// <param name="type">The result type.</param>
+        /// <param name="postfix">True if the <paramref name="unaryOperator"/> follows the operand; otherwise, false.</param>
+        /// <exception cref="ArgumentNullException" />
         public CustomUnaryExpression(
             [NotNull] Expression operand,
-            [NotNull] string @operator,
+            [NotNull] string unaryOperator,
             [NotNull] Type type,
-            bool postfix=false)
+            bool postfix = false)
         {
-            Check.NotNull(operand, nameof(operand));
-            Check.NotEmpty(@operator, nameof(@operator));
-            Check.NotNull(type, nameof(type));
-
-            Operand = operand;
-            Operator = @operator;
-            Type = type;
+            Operand = Check.NotNull(operand, nameof(operand));
+            Operator = Check.NotEmpty(unaryOperator, nameof(unaryOperator));
+            Type = Check.NotNull(type, nameof(type));
             Postfix = postfix;
         }
 
-        public Expression Operand { get; }
-        public string Operator { get; }
-        public override Type Type { get; }
-        public bool Postfix { get; }
-
-        public override ExpressionType NodeType => ExpressionType.Extension;
-
+        /// <inheritdoc />
         protected override Expression Accept(ExpressionVisitor visitor)
-        {
-            Check.NotNull(visitor, nameof(visitor));
-
-            return visitor is NpgsqlQuerySqlGenerator npgsqlGenerator
+            => visitor is NpgsqlQuerySqlGenerator npgsqlGenerator
                 ? npgsqlGenerator.VisitCustomUnary(this)
                 : base.Accept(visitor);
-        }
 
+        /// <inheritdoc />
         protected override Expression VisitChildren(ExpressionVisitor visitor)
         {
-            var newOperand = visitor.Visit(Operand);
+            var operand = visitor.Visit(Operand) ?? Operand;
 
-            return newOperand != Operand
-                ? new CustomUnaryExpression(newOperand, Operator, Type)
-                : this;
+            return
+                operand != Operand
+                    ? new CustomUnaryExpression(operand, Operator, Type)
+                    : this;
         }
 
-        public override string ToString() => Postfix
-            ? $"{Operator}{Operand}"
-            : $"{Operand}{Operator}";
+        /// <inheritdoc />
+        public override string ToString() => Postfix ? $"{Operator}{Operand}" : $"{Operand}{Operator}";
     }
 }

--- a/src/EFCore.PG/Query/Expressions/Internal/ILikeExpression.cs
+++ b/src/EFCore.PG/Query/Expressions/Internal/ILikeExpression.cs
@@ -1,4 +1,5 @@
 ﻿#region License
+
 // The PostgreSQL License
 //
 // Copyright (C) 2016 The Npgsql Development Team
@@ -19,162 +20,103 @@
 // AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS
 // ON AN "AS IS" BASIS, AND THE NPGSQL DEVELOPMENT TEAM HAS NO OBLIGATIONS
 // TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+
 #endregion
 
 using System;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Query.Sql.Internal;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Utilities;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.Expressions.Internal
 {
     /// <summary>
-    ///     Represents a SQL ILIKE expression.
+    /// Represents a PostgreSQL ILIKE expression.
     /// </summary>
-    public class ILikeExpression : Expression
+    // ReSharper disable once InconsistentNaming
+    public class ILikeExpression : Expression, IEquatable<ILikeExpression>
     {
-        /// <summary>
-        ///     Creates a new instance of LikeExpression.
-        /// </summary>
-        /// <param name="match"> The expression to match. </param>
-        /// <param name="pattern"> The pattern to match. </param>
-        public ILikeExpression([NotNull] Expression match, [NotNull] Expression pattern)
-        {
-            Check.NotNull(match, nameof(match));
-            Check.NotNull(pattern, nameof(pattern));
+        /// <inheritdoc />
+        public override ExpressionType NodeType => ExpressionType.Extension;
 
-            Match = match;
-            Pattern = pattern;
-        }
+        /// <inheritdoc />
+        public override Type Type => typeof(bool);
 
         /// <summary>
-        ///     Creates a new instance of LikeExpression.
+        /// The match expression.
         /// </summary>
-        /// <param name="match"> The expression to match. </param>
-        /// <param name="pattern"> The pattern to match. </param>
-        /// <param name="escapeChar"> The escape character to use in <paramref name="pattern"/>. </param>
-        public ILikeExpression([NotNull] Expression match, [NotNull] Expression pattern, [CanBeNull] Expression escapeChar)
-        {
-            Check.NotNull(match, nameof(match));
-            Check.NotNull(pattern, nameof(pattern));
-
-            Match = match;
-            Pattern = pattern;
-            EscapeChar = escapeChar;
-        }
-
-        /// <summary>
-        ///     Gets the match expression.
-        /// </summary>
-        /// <value>
-        ///     The match expression.
-        /// </value>
+        [NotNull]
         public virtual Expression Match { get; }
 
         /// <summary>
-        ///     Gets the pattern to match.
+        /// The pattern to match.
         /// </summary>
-        /// <value>
-        ///     The pattern to match.
-        /// </value>
+        [NotNull]
         public virtual Expression Pattern { get; }
 
         /// <summary>
-        ///     Gets the escape character to use in <see cref="Pattern"/>.
+        /// The escape character to use in <see cref="Pattern"/>.
         /// </summary>
-        /// <value>
-        ///     The escape character to use. If null, no escape character is used.
-        /// </value>
         [CanBeNull]
         public virtual Expression EscapeChar { get; }
 
         /// <summary>
-        ///     Returns the node type of this <see cref="Expression" />. (Inherited from <see cref="Expression" />.)
+        /// Constructs a <see cref="ILikeExpression"/>.
         /// </summary>
-        /// <returns>The <see cref="ExpressionType" /> that represents this expression.</returns>
-        public override ExpressionType NodeType => ExpressionType.Extension;
-
-        /// <summary>
-        ///     Gets the static type of the expression that this <see cref="Expression" /> represents. (Inherited from <see cref="Expression" />.)
-        /// </summary>
-        /// <returns>The <see cref="Type" /> that represents the static type of the expression.</returns>
-        public override Type Type => typeof(bool);
-
-        /// <summary>
-        ///     Dispatches to the specific visit method for this node type.
-        /// </summary>
-        protected override Expression Accept(ExpressionVisitor visitor)
+        /// <param name="match">The expression to match.</param>
+        /// <param name="pattern">The pattern to match.</param>
+        /// <exception cref="ArgumentNullException" />
+        public ILikeExpression([NotNull] Expression match, [NotNull] Expression pattern)
         {
-            Check.NotNull(visitor, nameof(visitor));
-
-            var specificVisitor = visitor as NpgsqlQuerySqlGenerator;
-
-            return specificVisitor != null
-                ? specificVisitor.VisitILike(this)
-                : base.Accept(visitor);
+            Match = Check.NotNull(match, nameof(match));
+            Pattern = Check.NotNull(pattern, nameof(pattern));
         }
 
         /// <summary>
-        ///     Reduces the node and then calls the <see cref="ExpressionVisitor.Visit(System.Linq.Expressions.Expression)" /> method passing the
-        ///     reduced expression.
-        ///     Throws an exception if the node isn't reducible.
+        /// Constructs a <see cref="ILikeExpression"/>.
         /// </summary>
-        /// <param name="visitor"> An instance of <see cref="ExpressionVisitor" />. </param>
-        /// <returns> The expression being visited, or an expression which should replace it in the tree. </returns>
-        /// <remarks>
-        ///     Override this method to provide logic to walk the node's children.
-        ///     A typical implementation will call visitor.Visit on each of its
-        ///     children, and if any of them change, should return a new copy of
-        ///     itself with the modified children.
-        /// </remarks>
+        /// <param name="match">The expression to match.</param>
+        /// <param name="pattern">The pattern to match.</param>
+        /// <param name="escapeChar">The escape character to use in <paramref name="pattern"/>.</param>
+        /// <exception cref="ArgumentNullException" />
+        public ILikeExpression([NotNull] Expression match, [NotNull] Expression pattern, [CanBeNull] Expression escapeChar)
+        {
+            Match = Check.NotNull(match, nameof(match));
+            Pattern = Check.NotNull(pattern, nameof(pattern));
+            EscapeChar = escapeChar;
+        }
+
+        /// <inheritdoc />
+        protected override Expression Accept(ExpressionVisitor visitor)
+            => visitor is NpgsqlQuerySqlGenerator npgsqlGenerator
+                ? npgsqlGenerator.VisitILike(this)
+                : base.Accept(visitor);
+
+        /// <inheritdoc />
         protected override Expression VisitChildren(ExpressionVisitor visitor)
         {
-            var newMatchExpression = visitor.Visit(Match);
-            var newPatternExpression = visitor.Visit(Pattern);
-            var newEscapeCharExpression = EscapeChar == null ? null : visitor.Visit(EscapeChar);
+            var match = visitor.Visit(Match) ?? Match;
+            var pattern = visitor.Visit(Pattern) ?? Pattern;
+            var escapeChar = visitor.Visit(EscapeChar);
 
-            return newMatchExpression != Match
-                   || newPatternExpression != Pattern
-                   || newEscapeCharExpression != EscapeChar
-                ? new ILikeExpression(newMatchExpression, newPatternExpression, newEscapeCharExpression)
-                : this;
+            return
+                match != Match || pattern != Pattern || escapeChar != EscapeChar
+                    ? new ILikeExpression(match, pattern, escapeChar)
+                    : this;
         }
 
-        /// <summary>
-        ///     Tests if this object is considered equal to another.
-        /// </summary>
-        /// <param name="obj"> The object to compare with the current object. </param>
-        /// <returns>
-        ///     true if the objects are considered equal, false if they are not.
-        /// </returns>
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj))
-            {
-                return false;
-            }
+        /// <inheritdoc />
+        public override bool Equals(object obj) => obj is ILikeExpression other && Equals(other);
 
-            if (ReferenceEquals(this, obj))
-            {
-                return true;
-            }
+        /// <inheritdoc />
+        public bool Equals(ILikeExpression other)
+            => other != null &&
+               Equals(Match, other.Match) &&
+               Equals(Pattern, other.Pattern) &&
+               Equals(EscapeChar, other.EscapeChar);
 
-            return obj.GetType() == GetType() && Equals((ILikeExpression)obj);
-        }
-
-        bool Equals(ILikeExpression other)
-            => Equals(Match, other.Match)
-               && Equals(Pattern, other.Pattern)
-               && Equals(EscapeChar, other.EscapeChar);
-
-        /// <summary>
-        ///     Returns a hash code for this object.
-        /// </summary>
-        /// <returns>
-        ///     A hash code for this object.
-        /// </returns>
+        /// <inheritdoc />
         public override int GetHashCode()
         {
             unchecked
@@ -182,15 +124,11 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.Expressions.Internal
                 var hashCode = Match.GetHashCode();
                 hashCode = (hashCode * 397) ^ Pattern.GetHashCode();
                 hashCode = (hashCode * 397) ^ (EscapeChar?.GetHashCode() ?? 0);
-
                 return hashCode;
             }
         }
 
-        /// <summary>
-        ///     Creates a <see cref="string" /> representation of the Expression.
-        /// </summary>
-        /// <returns>A <see cref="string" /> representation of the Expression.</returns>
+        /// <inheritdoc />
         public override string ToString() => $"{Match} ILIKE {Pattern}{(EscapeChar == null ? "" : $" ESCAPE {EscapeChar}")}";
     }
 }

--- a/src/EFCore.PG/Query/Expressions/Internal/RegexMatchExpression.cs
+++ b/src/EFCore.PG/Query/Expressions/Internal/RegexMatchExpression.cs
@@ -1,4 +1,5 @@
 #region License
+
 // The PostgreSQL License
 //
 // Copyright (C) 2016 The Npgsql Development Team
@@ -19,12 +20,14 @@
 // AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS
 // ON AN "AS IS" BASIS, AND THE NPGSQL DEVELOPMENT TEAM HAS NO OBLIGATIONS
 // TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+
 #endregion
 
 using System;
 using System.Linq.Expressions;
 using System.Text.RegularExpressions;
 using JetBrains.Annotations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionVisitors;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Query.Sql.Internal;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Utilities;
 
@@ -32,44 +35,62 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.Expressions.Internal
 {
     public class RegexMatchExpression : Expression
     {
+        /// <inheritdoc />
+        public override ExpressionType NodeType => ExpressionType.Extension;
+
+        /// <inheritdoc />
+        public override Type Type => typeof(bool);
+
+        /// <summary>
+        /// The match expression.
+        /// </summary>
+        [NotNull]
+        public virtual Expression Match { get; }
+
+        /// <summary>
+        /// The pattern to match.
+        /// </summary>
+        [NotNull]
+        public virtual Expression Pattern { get; }
+
+        /// <summary>
+        /// The options for regular expression evaluation.
+        /// </summary>
+        public RegexOptions Options { get; }
+
+        /// <summary>
+        /// Constructs a <see cref="RegexMatchExpression"/>.
+        /// </summary>
+        /// <param name="match">The expression to match.</param>
+        /// <param name="pattern">The pattern to match.</param>
+        /// <param name="options">The options for regular expression evaluation.</param>
+        /// <exception cref="ArgumentNullException" />
         public RegexMatchExpression([NotNull] Expression match, [NotNull] Expression pattern, RegexOptions options)
         {
-            Check.NotNull(match, nameof(match));
-            Check.NotNull(pattern, nameof(pattern));
-
-            Match = match;
-            Pattern = pattern;
+            Match = Check.NotNull(match, nameof(match));
+            Pattern = Check.NotNull(pattern, nameof(pattern));
             Options = options;
         }
 
-        public Expression Match { get; }
-        public Expression Pattern { get; }
-        public RegexOptions Options { get; }
-
-        public override ExpressionType NodeType => ExpressionType.Extension;
-
-        public override Type Type => typeof(bool);
-
-        protected override Expression Accept([NotNull] ExpressionVisitor visitor)
-        {
-            Check.NotNull(visitor, nameof(visitor));
-
-            return visitor is NpgsqlQuerySqlGenerator npsgqlGenerator
-                ? npsgqlGenerator.VisitRegexMatch(this)
+        /// <inheritdoc />
+        protected override Expression Accept(ExpressionVisitor visitor)
+            => visitor is NpgsqlQuerySqlGenerator npgsqlGenerator
+                ? npgsqlGenerator.VisitRegexMatch(this)
                 : base.Accept(visitor);
-        }
 
+        /// <inheritdoc />
         protected override Expression VisitChildren(ExpressionVisitor visitor)
         {
-            var newMatchExpression = visitor.Visit(Match);
-            var newPatternExpression = visitor.Visit(Pattern);
+            var match = visitor.Visit(Match) ?? Match;
+            var pattern = visitor.Visit(Pattern) ?? Pattern;
 
-            return newMatchExpression != Match
-                   || newPatternExpression != Pattern
-                ? new RegexMatchExpression(newMatchExpression, newPatternExpression, Options)
-                : this;
+            return
+                match != Match || pattern != Pattern
+                    ? new RegexMatchExpression(match, pattern, Options)
+                    : this;
         }
 
+        /// <inheritdoc />
         public override string ToString() => $"{Match} ~ {Pattern}";
     }
 }


### PR DESCRIPTION
~~We have several custom expression types that use the `ExpressionType.Extension`. These can be visited by overriding `VisitExtension(...)` rather than explicitly dispatching from the `Expression.Accept(...)` method.~~

~~This is partially cosmetic, but it also clarifies where we are (and are not) perturbing the normal behavior of a generic `ExpressionVisitor` pattern. Further, this also reduces the public API surface of the various expression visitors by moving all of the custom visits from `public` to `protected`.~~

Repurposing this PR to add doc comments and cleanup some inconsistencies in the extension expressions. 

Moved from #541.