### PR TITLE
In case of @@ operator with string RHS, wrap RHS with plain_totsquery.

### DIFF
--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlFullTextSearchMethodTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlFullTextSearchMethodTranslator.cs
@@ -94,7 +94,10 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Inte
                 return new CustomBinaryExpression(e.Arguments[0], e.Arguments[1], "<@", typeof(bool));
 
             case nameof(NpgsqlFullTextSearchLinqExtensions.Matches):
-                return new CustomBinaryExpression(e.Arguments[0], e.Arguments[1], "@@", typeof(bool));
+                var secondArgument = e.Arguments[1].Type == typeof(string)
+                    ? new SqlFunctionExpression("plainto_tsquery", typeof(NpgsqlTsQuery), new[] { e.Arguments[1] })
+                    : e.Arguments[1];
+                return new CustomBinaryExpression(e.Arguments[0], secondArgument, "@@", typeof(bool));
 
             case nameof(NpgsqlFullTextSearchLinqExtensions.Concat):
                 return new CustomBinaryExpression(e.Arguments[0], e.Arguments[1], "||", typeof(NpgsqlTsVector));

--- a/test/EFCore.PG.FunctionalTests/Query/FullTextSearchDbFunctionsNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/FullTextSearchDbFunctionsNpgsqlTest.cs
@@ -429,14 +429,17 @@ LIMIT 1");
         {
             using (var context = CreateContext())
             {
+                var query = "b";
                 var result = context.Customers
-                    .Select(c => EF.Functions.ToTsVector("a").Matches("b"))
+                    .Select(c => EF.Functions.ToTsVector("a").Matches(query))
                     .First();
                 Assert.False(result);
             }
 
             AssertSql(
-                @"SELECT (to_tsvector('a') @@ 'b')
+                @"@__query_1='b'
+
+SELECT (to_tsvector('a') @@ plainto_tsquery(@__query_1))
 FROM ""Customers"" AS c
 LIMIT 1");
         }


### PR DESCRIPTION
Hey @roji,
This should fix #562 
It turns out while I was implementing the Matches operator function, I had misread the PostgreSQL docs, specifically this part in https://www.postgresql.org/docs/current/static/textsearch-intro.html:

> > tsvector @@ tsquery
> > tsquery  @@ tsvector
> > text @@ tsquery
> > text @@ text
>
> The first two of these we saw already. The form text @@ tsquery is equivalent to to_tsvector(x) @@ y. The form text @@ text is equivalent to to_tsvector(x) @@ plainto_tsquery(y).

I imagined there was a `tsvector @@ text` overload and implemented a `Matches` method that took a string parameter in addition to the overload that takes `NpgsqlTsQuery`. Strangely enough, the unit test for this was passing but I now I think that it was due to the test passing the string as a literal constant to the Matches method and Npgsql embedding the literal directly in the SQL thus allowing the PostgreSQL type coercion to work. 

However, when it is passed as a parameter, Npgsql sends the parameter with explicit type of 'text' which causes PostgreSQL to fail since it won't do type coercion when the types are specified explicitly in the query protocol for the parameters and there is no `tsvector @@ text` overload.

Since this method is already public (albeit it probably never worked since day 1), I will keep it as-is but instead I had the SQL translator manually wrap it with `plainto_tsquery` which will match the intended behavior of PostgreSQL for string overloads of the ```@@```.

I also updated the unit test.