### PR TITLE
Translate SystemClock.GetCurrentInstant() for NodaTime

### DIFF
--- a/src/EFCore.PG.NodaTime/NodaTimeDbContextOptionsExtensions.cs
+++ b/src/EFCore.PG.NodaTime/NodaTimeDbContextOptionsExtensions.cs
@@ -1,4 +1,30 @@
-﻿using JetBrains.Annotations;
+﻿#region License
+
+// The PostgreSQL License
+//
+// Copyright (C) 2016 The Npgsql Development Team
+//
+// Permission to use, copy, modify, and distribute this software and its
+// documentation for any purpose, without fee, and without a written
+// agreement is hereby granted, provided that the above copyright notice
+// and this paragraph and the following two paragraphs appear in all copies.
+//
+// IN NO EVENT SHALL THE NPGSQL DEVELOPMENT TEAM BE LIABLE TO ANY PARTY
+// FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES,
+// INCLUDING LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS
+// DOCUMENTATION, EVEN IF THE NPGSQL DEVELOPMENT TEAM HAS BEEN ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//
+// THE NPGSQL DEVELOPMENT TEAM SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS
+// ON AN "AS IS" BASIS, AND THE NPGSQL DEVELOPMENT TEAM HAS NO OBLIGATIONS
+// TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+
+#endregion
+
+using System;
+using JetBrains.Annotations;
 using Npgsql;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure;
 using Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime;
@@ -7,10 +33,21 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Utilities;
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {
+    /// <summary>
+    /// Provides extension methods for the NodaTime plugin for the Npgsql Entity Framework Core provider.
+    /// </summary>
     public static class NodaTimeDbContextOptionsExtensions
     {
-        public static NpgsqlDbContextOptionsBuilder UseNodaTime(
-            [NotNull] this NpgsqlDbContextOptionsBuilder optionsBuilder)
+        /// <summary>
+        /// Registers the NodaTime plugin for the Npgsql Entity Framework Core provider.
+        /// </summary>
+        /// <param name="optionsBuilder">The options builder.</param>
+        /// <returns>
+        /// The options builder configured with the NodaTime plugin.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="optionsBuilder"/></exception>
+        [NotNull]
+        public static NpgsqlDbContextOptionsBuilder UseNodaTime([NotNull] this NpgsqlDbContextOptionsBuilder optionsBuilder)
         {
             Check.NotNull(optionsBuilder, nameof(optionsBuilder));
 

--- a/src/EFCore.PG.NodaTime/NodaTimeEvaluatableExpressionFilter.cs
+++ b/src/EFCore.PG.NodaTime/NodaTimeEvaluatableExpressionFilter.cs
@@ -1,0 +1,86 @@
+﻿#region License
+
+// The PostgreSQL License
+//
+// Copyright (C) 2016 The Npgsql Development Team
+//
+// Permission to use, copy, modify, and distribute this software and its
+// documentation for any purpose, without fee, and without a written
+// agreement is hereby granted, provided that the above copyright notice
+// and this paragraph and the following two paragraphs appear in all copies.
+//
+// IN NO EVENT SHALL THE NPGSQL DEVELOPMENT TEAM BE LIABLE TO ANY PARTY
+// FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES,
+// INCLUDING LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS
+// DOCUMENTATION, EVEN IF THE NPGSQL DEVELOPMENT TEAM HAS BEEN ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//
+// THE NPGSQL DEVELOPMENT TEAM SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS
+// ON AN "AS IS" BASIS, AND THE NPGSQL DEVELOPMENT TEAM HAS NO OBLIGATIONS
+// TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+
+#endregion
+
+using System;
+using System.Linq.Expressions;
+using System.Reflection;
+using JetBrains.Annotations;
+using NodaTime;
+using Remotion.Linq.Parsing.ExpressionVisitors.TreeEvaluation;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime
+{
+    /// <summary>
+    /// Represents an Npgsql-specific filter for NodaTime to identify expressions that are evaluatable.
+    /// </summary>
+    public class NodaTimeEvaluatableExpressionFilter : IEvaluatableExpressionFilter
+    {
+        /// <summary>
+        /// The static member info for <see cref="T:SystemClock.Instance"/>.
+        /// </summary>
+        [NotNull] static readonly MemberInfo Instance =
+            typeof(SystemClock).GetRuntimeProperty(nameof(SystemClock.Instance));
+
+        /// <summary>
+        /// The static method info for <see cref="T:SystemClock.GetCurrentInstant()"/>.
+        /// </summary>
+        [NotNull] static readonly MethodInfo GetCurrentInstant =
+            typeof(SystemClock).GetRuntimeMethod(nameof(SystemClock.GetCurrentInstant), new Type[0]);
+
+        /// <inheritdoc />
+        public bool IsEvaluatableMember(MemberExpression node) => node.Member != Instance;
+
+        /// <inheritdoc />
+        public bool IsEvaluatableMethodCall(MethodCallExpression node) => node.Method != GetCurrentInstant;
+
+        bool IEvaluatableExpressionFilter.IsEvaluatableBinary(BinaryExpression node) => true;
+        bool IEvaluatableExpressionFilter.IsEvaluatableConditional(ConditionalExpression node) => true;
+        bool IEvaluatableExpressionFilter.IsEvaluatableConstant(ConstantExpression node) => true;
+        bool IEvaluatableExpressionFilter.IsEvaluatableElementInit(ElementInit node) => true;
+        bool IEvaluatableExpressionFilter.IsEvaluatableInvocation(InvocationExpression node) => true;
+        bool IEvaluatableExpressionFilter.IsEvaluatableLambda(LambdaExpression node) => true;
+        bool IEvaluatableExpressionFilter.IsEvaluatableListInit(ListInitExpression node) => true;
+        bool IEvaluatableExpressionFilter.IsEvaluatableMemberAssignment(MemberAssignment node) => true;
+        bool IEvaluatableExpressionFilter.IsEvaluatableMemberInit(MemberInitExpression node) => true;
+        bool IEvaluatableExpressionFilter.IsEvaluatableMemberListBinding(MemberListBinding node) => true;
+        bool IEvaluatableExpressionFilter.IsEvaluatableMemberMemberBinding(MemberMemberBinding node) => true;
+        bool IEvaluatableExpressionFilter.IsEvaluatableNew(NewExpression node) => true;
+        bool IEvaluatableExpressionFilter.IsEvaluatableNewArray(NewArrayExpression node) => true;
+        bool IEvaluatableExpressionFilter.IsEvaluatableTypeBinary(TypeBinaryExpression node) => true;
+        bool IEvaluatableExpressionFilter.IsEvaluatableUnary(UnaryExpression node) => true;
+        bool IEvaluatableExpressionFilter.IsEvaluatableBlock(BlockExpression node) => true;
+        bool IEvaluatableExpressionFilter.IsEvaluatableCatchBlock(CatchBlock node) => true;
+        bool IEvaluatableExpressionFilter.IsEvaluatableDebugInfo(DebugInfoExpression node) => true;
+        bool IEvaluatableExpressionFilter.IsEvaluatableDefault(DefaultExpression node) => true;
+        bool IEvaluatableExpressionFilter.IsEvaluatableGoto(GotoExpression node) => true;
+        bool IEvaluatableExpressionFilter.IsEvaluatableIndex(IndexExpression node) => true;
+        bool IEvaluatableExpressionFilter.IsEvaluatableLabel(LabelExpression node) => true;
+        bool IEvaluatableExpressionFilter.IsEvaluatableLabelTarget(LabelTarget node) => true;
+        bool IEvaluatableExpressionFilter.IsEvaluatableLoop(LoopExpression node) => true;
+        bool IEvaluatableExpressionFilter.IsEvaluatableSwitch(SwitchExpression node) => true;
+        bool IEvaluatableExpressionFilter.IsEvaluatableSwitchCase(SwitchCase node) => true;
+        bool IEvaluatableExpressionFilter.IsEvaluatableTry(TryExpression node) => true;
+    }
+}

--- a/src/EFCore.PG.NodaTime/NodaTimeEvaluatableExpressionFilter.cs
+++ b/src/EFCore.PG.NodaTime/NodaTimeEvaluatableExpressionFilter.cs
@@ -55,6 +55,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime
         /// <inheritdoc />
         public bool IsEvaluatableMethodCall(MethodCallExpression node) => node.Method != GetCurrentInstant;
 
+        #region unused interface methods
+
         bool IEvaluatableExpressionFilter.IsEvaluatableBinary(BinaryExpression node) => true;
         bool IEvaluatableExpressionFilter.IsEvaluatableConditional(ConditionalExpression node) => true;
         bool IEvaluatableExpressionFilter.IsEvaluatableConstant(ConstantExpression node) => true;
@@ -82,5 +84,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime
         bool IEvaluatableExpressionFilter.IsEvaluatableSwitch(SwitchExpression node) => true;
         bool IEvaluatableExpressionFilter.IsEvaluatableSwitchCase(SwitchCase node) => true;
         bool IEvaluatableExpressionFilter.IsEvaluatableTry(TryExpression node) => true;
+
+        #endregion
     }
 }

--- a/src/EFCore.PG.NodaTime/NodaTimeMappings.cs
+++ b/src/EFCore.PG.NodaTime/NodaTimeMappings.cs
@@ -1,4 +1,28 @@
-﻿using System;
+﻿#region License
+
+// The PostgreSQL License
+//
+// Copyright (C) 2016 The Npgsql Development Team
+//
+// Permission to use, copy, modify, and distribute this software and its
+// documentation for any purpose, without fee, and without a written
+// agreement is hereby granted, provided that the above copyright notice
+// and this paragraph and the following two paragraphs appear in all copies.
+//
+// IN NO EVENT SHALL THE NPGSQL DEVELOPMENT TEAM BE LIABLE TO ANY PARTY
+// FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES,
+// INCLUDING LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS
+// DOCUMENTATION, EVEN IF THE NPGSQL DEVELOPMENT TEAM HAS BEEN ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//
+// THE NPGSQL DEVELOPMENT TEAM SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS
+// ON AN "AS IS" BASIS, AND THE NPGSQL DEVELOPMENT TEAM HAS NO OBLIGATIONS
+// TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+
+#endregion
+
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;

--- a/src/EFCore.PG.NodaTime/NodaTimeMethodCallTranslator.cs
+++ b/src/EFCore.PG.NodaTime/NodaTimeMethodCallTranslator.cs
@@ -1,0 +1,55 @@
+﻿#region License
+
+// The PostgreSQL License
+//
+// Copyright (C) 2016 The Npgsql Development Team
+//
+// Permission to use, copy, modify, and distribute this software and its
+// documentation for any purpose, without fee, and without a written
+// agreement is hereby granted, provided that the above copyright notice
+// and this paragraph and the following two paragraphs appear in all copies.
+//
+// IN NO EVENT SHALL THE NPGSQL DEVELOPMENT TEAM BE LIABLE TO ANY PARTY
+// FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES,
+// INCLUDING LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS
+// DOCUMENTATION, EVEN IF THE NPGSQL DEVELOPMENT TEAM HAS BEEN ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//
+// THE NPGSQL DEVELOPMENT TEAM SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS
+// ON AN "AS IS" BASIS, AND THE NPGSQL DEVELOPMENT TEAM HAS NO OBLIGATIONS
+// TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+
+#endregion
+
+using System;
+using System.Linq.Expressions;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Query.Expressions;
+using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
+using NodaTime;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Query.Expressions.Internal;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime
+{
+    /// <summary>
+    /// Provides translation services for NodaTime method calls.
+    /// </summary>
+    public class NodaTimeMethodCallTranslator : IMethodCallTranslator
+    {
+        /// <summary>
+        /// The static method info for <see cref="T:SystemClock.GetCurrentInstant()"/>.
+        /// </summary>
+        [NotNull] static readonly MethodInfo GetCurrentInstant =
+            typeof(SystemClock).GetRuntimeMethod(nameof(SystemClock.GetCurrentInstant), Type.EmptyTypes);
+
+        /// <inheritdoc />
+        [CanBeNull]
+        public Expression Translate(MethodCallExpression expression)
+            => expression.Method == GetCurrentInstant
+                ? new AtTimeZoneExpression(new SqlFunctionExpression("NOW", expression.Type), "UTC", expression.Type)
+                : null;
+    }
+}

--- a/src/EFCore.PG.NodaTime/NodaTimePlugin.cs
+++ b/src/EFCore.PG.NodaTime/NodaTimePlugin.cs
@@ -1,54 +1,116 @@
-﻿using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
+﻿#region License
+
+// The PostgreSQL License
+//
+// Copyright (C) 2016 The Npgsql Development Team
+//
+// Permission to use, copy, modify, and distribute this software and its
+// documentation for any purpose, without fee, and without a written
+// agreement is hereby granted, provided that the above copyright notice
+// and this paragraph and the following two paragraphs appear in all copies.
+//
+// IN NO EVENT SHALL THE NPGSQL DEVELOPMENT TEAM BE LIABLE TO ANY PARTY
+// FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES,
+// INCLUDING LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS
+// DOCUMENTATION, EVEN IF THE NPGSQL DEVELOPMENT TEAM HAS BEEN ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//
+// THE NPGSQL DEVELOPMENT TEAM SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS
+// ON AN "AS IS" BASIS, AND THE NPGSQL DEVELOPMENT TEAM HAS NO OBLIGATIONS
+// TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+
+#endregion
+
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 using Microsoft.EntityFrameworkCore.Storage;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Query.EvaluatableExpressionFilters.Internal;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Internal;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping;
 using NpgsqlTypes;
+using Remotion.Linq.Parsing.ExpressionVisitors.TreeEvaluation;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime
 {
+    /// <summary>
+    /// The NodaTime plugin for the Npgsql Entity Framework Core provider.
+    /// </summary>
     public class NodaTimePlugin : NpgsqlEntityFrameworkPlugin
     {
+        #region TypeMapping
+
+        [NotNull] readonly TimestampInstantMapping _timestampInstant = new TimestampInstantMapping();
+        [NotNull] readonly TimestampLocalDateTimeMapping _timestampLocalDateTime = new TimestampLocalDateTimeMapping();
+
+        [NotNull] readonly TimestampTzInstantMapping _timestamptzInstant = new TimestampTzInstantMapping();
+        [NotNull] readonly TimestampTzZonedDateTimeMapping _timestamptzZonedDateTime = new TimestampTzZonedDateTimeMapping();
+        [NotNull] readonly TimestampTzOffsetDateTimeMapping _timestamptzOffsetDateTime = new TimestampTzOffsetDateTimeMapping();
+
+        [NotNull] readonly DateMapping _date = new DateMapping();
+        [NotNull] readonly TimeMapping _time = new TimeMapping();
+        [NotNull] readonly TimeTzMapping _timetz = new TimeTzMapping();
+        [NotNull] readonly IntervalMapping _period = new IntervalMapping();
+
+        [NotNull] readonly NpgsqlRangeTypeMapping<LocalDateTime> _timestampLocalDateTimeRange;
+        [NotNull] readonly NpgsqlRangeTypeMapping<Instant> _timestampInstantRange;
+        [NotNull] readonly NpgsqlRangeTypeMapping<Instant> _timestamptzInstantRange;
+        [NotNull] readonly NpgsqlRangeTypeMapping<ZonedDateTime> _timestamptzZonedDateTimeRange;
+        [NotNull] readonly NpgsqlRangeTypeMapping<OffsetDateTime> _timestamptzOffsetDateTimeRange;
+        [NotNull] readonly NpgsqlRangeTypeMapping<LocalDate> _dateRange;
+
+        #endregion
+
+        /// <summary>
+        /// The default member translators registered by the Npgsql NodaTime plugin.
+        /// </summary>
+        [NotNull] static readonly IMemberTranslator[] MemberTranslators = { new NodaTimeMemberTranslator() };
+
+        /// <summary>
+        /// The default method call translators registered by the Npgsql NodaTime plugin.
+        /// </summary>
+        [NotNull] static readonly IMethodCallTranslator[] MethodCallTranslators = { new NodaTimeMethodCallTranslator() };
+
+        /// <summary>
+        /// The default evaluatable expression filters registered by the Npgsql NodaTime plugin.
+        /// </summary>
+        [NotNull] static readonly IEvaluatableExpressionFilter[] EvaluatableExpressionFilters = { new NodaTimeEvaluatableExpressionFilter() };
+
+        /// <inheritdoc />
         public override string Name => "NodaTime";
+
+        /// <inheritdoc />
         public override string Description => "Plugin to map NodaTime types to PostgreSQL date/time datatypes";
 
-        readonly TimestampInstantMapping _timestampInstant = new TimestampInstantMapping();
-        readonly TimestampLocalDateTimeMapping _timestampLocalDateTime = new TimestampLocalDateTimeMapping();
-
-        readonly TimestampTzInstantMapping _timestamptzInstant = new TimestampTzInstantMapping();
-        readonly TimestampTzZonedDateTimeMapping _timestamptzZonedDateTime = new TimestampTzZonedDateTimeMapping();
-        readonly TimestampTzOffsetDateTimeMapping _timestamptzOffsetDateTime = new TimestampTzOffsetDateTimeMapping();
-
-        readonly DateMapping _date = new DateMapping();
-        readonly TimeMapping _time = new TimeMapping();
-        readonly TimeTzMapping _timetz = new TimeTzMapping();
-        readonly IntervalMapping _period = new IntervalMapping();
-
-        readonly NpgsqlRangeTypeMapping<LocalDateTime> _timestampLocalDateTimeRange;
-        readonly NpgsqlRangeTypeMapping<Instant> _timestampInstantRange;
-        readonly NpgsqlRangeTypeMapping<Instant> _timestamptzInstantRange;
-        readonly NpgsqlRangeTypeMapping<ZonedDateTime> _timestamptzZonedDateTimeRange;
-        readonly NpgsqlRangeTypeMapping<OffsetDateTime> _timestamptzOffsetDateTimeRange;
-        readonly NpgsqlRangeTypeMapping<LocalDate> _dateRange;
-
+        /// <summary>
+        /// Constructs an instance of the <see cref="NodaTimePlugin"/> class.
+        /// </summary>
         public NodaTimePlugin()
         {
             _timestampLocalDateTimeRange = new NpgsqlRangeTypeMapping<LocalDateTime>(
                 "tsrange", typeof(NpgsqlRange<LocalDateTime>), _timestampLocalDateTime, NpgsqlDbType.Range | NpgsqlDbType.Timestamp);
+
             _timestampInstantRange = new NpgsqlRangeTypeMapping<Instant>(
                 "tsrange", typeof(NpgsqlRange<Instant>), _timestampInstant, NpgsqlDbType.Range | NpgsqlDbType.Timestamp);
+
             _timestamptzInstantRange = new NpgsqlRangeTypeMapping<Instant>(
                 "tstzrange", typeof(NpgsqlRange<Instant>), _timestamptzInstant, NpgsqlDbType.Range | NpgsqlDbType.TimestampTz);
+
             _timestamptzZonedDateTimeRange = new NpgsqlRangeTypeMapping<ZonedDateTime>(
                 "tstzrange", typeof(NpgsqlRange<ZonedDateTime>), _timestamptzZonedDateTime, NpgsqlDbType.Range | NpgsqlDbType.TimestampTz);
+
             _timestamptzOffsetDateTimeRange = new NpgsqlRangeTypeMapping<OffsetDateTime>(
                 "tstzrange", typeof(NpgsqlRange<OffsetDateTime>), _timestamptzOffsetDateTime, NpgsqlDbType.Range | NpgsqlDbType.TimestampTz);
+
             _dateRange = new NpgsqlRangeTypeMapping<LocalDate>(
-                "daterange", typeof(NpgsqlRange<LocalDate>), _date, NpgsqlDbType.Range | NpgsqlDbType.Date);;
+                "daterange", typeof(NpgsqlRange<LocalDate>), _date, NpgsqlDbType.Range | NpgsqlDbType.Date);
         }
 
+        /// <inheritdoc />
         public override void AddMappings(NpgsqlTypeMappingSource typeMappingSource)
         {
             typeMappingSource.ClrTypeMappings[typeof(Instant)] = _timestampInstant;
@@ -94,12 +156,16 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime
             typeMappingSource.StoreTypeMappings["daterange"] = new RelationalTypeMapping[] { _dateRange };
         }
 
-        static readonly IMemberTranslator[] MemberTranslators =
-        {
-            new NodaTimeMemberTranslator()
-        };
-
+        /// <inheritdoc />
         public override void AddMemberTranslators(NpgsqlCompositeMemberTranslator compositeMemberTranslator)
             => compositeMemberTranslator.AddTranslators(MemberTranslators);
+
+        /// <inheritdoc />
+        public override void AddMethodCallTranslators(NpgsqlCompositeMethodCallTranslator compositeMethodCallTranslator)
+            => compositeMethodCallTranslator.AddTranslators(MethodCallTranslators);
+
+        /// <inheritdoc />
+        public override void AddEvaluatableExpressionFilters(NpgsqlCompositeEvaluatableExpressionFilter compositeEvaluatableExpressionFilter)
+            => compositeEvaluatableExpressionFilter.AddFilters(EvaluatableExpressionFilters);
     }
 }

--- a/src/EFCore.PG/Query/EvaluatableExpressionFilters/Internal/NpgsqlFullTextSearchEvaluatableExpressionFilter.cs
+++ b/src/EFCore.PG/Query/EvaluatableExpressionFilters/Internal/NpgsqlFullTextSearchEvaluatableExpressionFilter.cs
@@ -58,6 +58,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.EvaluatableExpressionFilte
                node.Method.DeclaringType != typeof(NpgsqlFullTextSearchDbFunctionsExtensions) &&
                node.Method.DeclaringType != typeof(NpgsqlFullTextSearchLinqExtensions);
 
+        #region unused interface methods
+
         bool IEvaluatableExpressionFilter.IsEvaluatableBinary(BinaryExpression node) => true;
         bool IEvaluatableExpressionFilter.IsEvaluatableConditional(ConditionalExpression node) => true;
         bool IEvaluatableExpressionFilter.IsEvaluatableConstant(ConstantExpression node) => true;
@@ -86,5 +88,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.EvaluatableExpressionFilte
         bool IEvaluatableExpressionFilter.IsEvaluatableSwitch(SwitchExpression node) => true;
         bool IEvaluatableExpressionFilter.IsEvaluatableSwitchCase(SwitchCase node) => true;
         bool IEvaluatableExpressionFilter.IsEvaluatableTry(TryExpression node) => true;
+
+        #endregion
     }
 }

--- a/test/EFCore.PG.Plugins.FunctionalTests/NodaTimeTest.cs
+++ b/test/EFCore.PG.Plugins.FunctionalTests/NodaTimeTest.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
@@ -323,6 +322,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL
             }
         }
 */
+
         #endregion Period members
 
         #region Range
@@ -332,12 +332,26 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL
         {
             using (var ctx = CreateContext())
             {
-                var d = ctx.NodaTimeTypes.Single(t => t.DateRange.Contains(new LocalDate(2018, 4, 21)));
+                var _ = ctx.NodaTimeTypes.Single(t => t.DateRange.Contains(new LocalDate(2018, 4, 21)));
                 Assert.Contains(@"t.""DateRange"" @> DATE '2018-04-21'", Sql);
             }
         }
 
         #endregion Range
+
+        #region GetCurrentInstant()
+
+        [Fact]
+        public void GetCurrentInstant_from_Instance()
+        {
+            using (var ctx = CreateContext())
+            {
+                var _ = ctx.NodaTimeTypes.Where(t => t.Instant < SystemClock.Instance.GetCurrentInstant()).ToArray();
+                Assert.Contains("WHERE t.\"Instant\" < NOW() AT TIME ZONE 'UTC'", Sql);
+            }
+        }
+
+        #endregion
 
         #region Support
 


### PR DESCRIPTION
Translates `SystemClock.Instance.GetCurrentInstant()` to `NOW() AT TIME ZONE 'UTC'`.

## TODO
- [x] Split xml docs and general refactorings into a separate PR.
- [x] Update test suite for `SystemClock.GetCurentInstant()`.

## Awaiting
- [x] #579
- [x] #580
- [x] #581

## Related
#502