### PR TITLE
Update mapping for character(n)

### DIFF
--- a/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlCharacterTypeMapping.cs
+++ b/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlCharacterTypeMapping.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Data.Common;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
+{
+    /// <inheritdoc />
+    /// <summary>
+    ///
+    /// </summary>
+    /// <remarks>
+    /// See: https://www.postgresql.org/docs/current/static/datatype-character.html
+    /// </remarks>
+    public class NpgsqlCharacterTypeMapping : NpgsqlStringTypeMapping
+    {
+        /// <summary>
+        /// Static <see cref="ValueComparer{T}"/> for fixed-width character types.
+        /// </summary>
+        [NotNull] static readonly ValueComparer<string> CharacterValueComparer =
+            new ValueComparer<string>(
+                (x, y) => x != null && y != null && x.AsSpan().TrimEnd() == y.AsSpan().TrimEnd(),
+                x => x != null ? x.TrimEnd().GetHashCode() : 0);
+
+        public override ValueComparer Comparer => CharacterValueComparer;
+
+        public override ValueComparer KeyComparer => CharacterValueComparer;
+
+        public NpgsqlCharacterTypeMapping([NotNull] string storeType, bool unicode = false, int? size = null)
+            : base(storeType, unicode, size) {}
+
+        protected NpgsqlCharacterTypeMapping(RelationalTypeMappingParameters parameters)
+            : base(parameters) {}
+
+        protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+            => new NpgsqlCharacterTypeMapping(parameters);
+
+        protected override void ConfigureParameter(DbParameter parameter)
+        {
+            var value = parameter.Value as string;
+
+            if (value != null)
+                parameter.Value = value.TrimEnd();
+
+            // See #357
+            if (Size.HasValue)
+                parameter.Size = parameter.Value == DBNull.Value || value == null || value.Length <= Size.Value ? Size.Value : -1;
+        }
+    }
+}

--- a/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlCharacterTypeMapping.cs
+++ b/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlCharacterTypeMapping.cs
@@ -6,18 +6,24 @@ using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
 {
-    /// <inheritdoc />
     /// <summary>
-    ///
+    /// The type mapping for the PostgreSQL 'character' data type.
     /// </summary>
     /// <remarks>
     /// See: https://www.postgresql.org/docs/current/static/datatype-character.html
     /// </remarks>
+    /// <inheritdoc />
     public class NpgsqlCharacterTypeMapping : NpgsqlStringTypeMapping
     {
         /// <summary>
         /// Static <see cref="ValueComparer{T}"/> for fixed-width character types.
         /// </summary>
+        /// <remarks>
+        /// Comparisons of 'character' data as defined in the SQL standard
+        /// differ dramatically from CLR string comparisons. This value comparer
+        /// adjusts for this by only comparing strings after truncating trailing
+        /// whitespace.
+        /// </remarks>
         [NotNull] static readonly ValueComparer<string> CharacterValueComparer =
             new ValueComparer<string>(
                 (x, y) => x != null && y != null && x.AsSpan().TrimEnd() == y.AsSpan().TrimEnd(),
@@ -30,22 +36,17 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
         public NpgsqlCharacterTypeMapping([NotNull] string storeType, bool unicode = false, int? size = null)
             : base(storeType, unicode, size) {}
 
-        protected NpgsqlCharacterTypeMapping(RelationalTypeMappingParameters parameters)
-            : base(parameters) {}
+        protected NpgsqlCharacterTypeMapping(RelationalTypeMappingParameters parameters) : base(parameters) {}
 
         protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
             => new NpgsqlCharacterTypeMapping(parameters);
 
         protected override void ConfigureParameter(DbParameter parameter)
         {
-            var value = parameter.Value as string;
-
-            if (value != null)
+            if (parameter.Value is string value)
                 parameter.Value = value.TrimEnd();
 
-            // See #357
-            if (Size.HasValue)
-                parameter.Size = parameter.Value == DBNull.Value || value == null || value.Length <= Size.Value ? Size.Value : -1;
+            base.ConfigureParameter(parameter);
         }
     }
 }

--- a/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlStringTypeMapping.cs
+++ b/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlStringTypeMapping.cs
@@ -5,28 +5,26 @@ using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
 {
-    // TODO: See #357. We should be able to simply use StringTypeMapping but DbParameter.Size isn't managed properly.
-    /// <inheritdoc />
     /// <summary>
-    ///
+    /// The type mapping for the PostgreSQL 'text' data type.
     /// </summary>
     /// <remarks>
-    ///
+    /// See: https://www.postgresql.org/docs/current/static/datatype-character.html
     /// </remarks>
+    /// <inheritdoc />
     public class NpgsqlStringTypeMapping : StringTypeMapping
     {
         public NpgsqlStringTypeMapping([NotNull] string storeType, bool unicode = false, int? size = null)
             : base(storeType, System.Data.DbType.String, unicode, size) {}
 
-        protected NpgsqlStringTypeMapping(RelationalTypeMappingParameters parameters)
-            : base(parameters) {}
+        protected NpgsqlStringTypeMapping(RelationalTypeMappingParameters parameters) : base(parameters) {}
 
         protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
             => new NpgsqlStringTypeMapping(parameters);
 
         protected override void ConfigureParameter(DbParameter parameter)
         {
-            // See #357
+            // TODO: See #357. We should be able to simply use StringTypeMapping but DbParameter.Size isn't managed properly.
             if (Size.HasValue)
             {
                 var value = parameter.Value;

--- a/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlStringTypeMapping.cs
+++ b/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlStringTypeMapping.cs
@@ -1,66 +1,31 @@
 ﻿using System;
 using System.Data.Common;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
 {
     // TODO: See #357. We should be able to simply use StringTypeMapping but DbParameter.Size isn't managed properly.
+    /// <inheritdoc />
+    /// <summary>
+    ///
+    /// </summary>
+    /// <remarks>
+    ///
+    /// </remarks>
     public class NpgsqlStringTypeMapping : StringTypeMapping
     {
-        /// <summary>
-        /// Static <see cref="ValueComparer{T}"/> for fixed-width character types.
-        /// </summary>
-        /// <remarks>
-        /// See: https://www.postgresql.org/docs/current/static/datatype-character.html
-        /// </remarks>
-        [NotNull] static readonly ValueComparer<string> CharacterValueComparer =
-            new ValueComparer<string>(
-                (x, y) => x != null && y != null && x.AsSpan().TrimEnd() == y.AsSpan().TrimEnd(),
-                x => x != null ? x.TrimEnd().GetHashCode() : 0);
+        public NpgsqlStringTypeMapping([NotNull] string storeType, bool unicode = false, int? size = null)
+            : base(storeType, System.Data.DbType.String, unicode, size) {}
 
-        /// <inheritdoc />
-        public override ValueComparer Comparer { get; }
+        protected NpgsqlStringTypeMapping(RelationalTypeMappingParameters parameters)
+            : base(parameters) {}
 
-        /// <inheritdoc />
-        public override ValueComparer KeyComparer { get; }
-
-        public NpgsqlStringTypeMapping(
-            [NotNull] string storeType,
-            DbType dbType = System.Data.DbType.String,
-            bool unicode = false,
-            int? size = null)
-            : base(storeType, dbType, unicode, size)
-        {
-            if (storeType == "character" && dbType == System.Data.DbType.StringFixedLength)
-            {
-                Comparer = CharacterValueComparer;
-                KeyComparer = CharacterValueComparer;
-            }
-        }
-
-        /// <inheritdoc />
-        protected NpgsqlStringTypeMapping(
-            RelationalTypeMappingParameters parameters,
-            ValueComparer comparer,
-            ValueComparer keyComparer)
-            : base(parameters)
-        {
-            Comparer = comparer;
-            KeyComparer = keyComparer;
-        }
-
-        /// <inheritdoc />
         protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
-            => new NpgsqlStringTypeMapping(parameters, Comparer, KeyComparer);
+            => new NpgsqlStringTypeMapping(parameters);
 
-        /// <inheritdoc />
         protected override void ConfigureParameter(DbParameter parameter)
         {
-            if (parameter.DbType == System.Data.DbType.StringFixedLength)
-                parameter.Value = (parameter.Value as string)?.TrimEnd() ?? string.Empty;
-
             // See #357
             if (Size.HasValue)
             {

--- a/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlStringTypeMapping.cs
+++ b/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlStringTypeMapping.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Data.Common;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
@@ -8,16 +9,58 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
     // TODO: See #357. We should be able to simply use StringTypeMapping but DbParameter.Size isn't managed properly.
     public class NpgsqlStringTypeMapping : StringTypeMapping
     {
-        public NpgsqlStringTypeMapping([NotNull] string storeType, bool unicode = false, int? size = null)
-            : base(storeType, System.Data.DbType.String, unicode, size) {}
+        /// <summary>
+        /// Static <see cref="ValueComparer{T}"/> for fixed-width character types.
+        /// </summary>
+        /// <remarks>
+        /// See: https://www.postgresql.org/docs/current/static/datatype-character.html
+        /// </remarks>
+        [NotNull] static readonly ValueComparer<string> CharacterValueComparer =
+            new ValueComparer<string>(
+                (x, y) => x != null && y != null && x.AsSpan().TrimEnd() == y.AsSpan().TrimEnd(),
+                x => x != null ? x.TrimEnd().GetHashCode() : 0);
 
-        protected NpgsqlStringTypeMapping(RelationalTypeMappingParameters parameters) : base(parameters) {}
+        /// <inheritdoc />
+        public override ValueComparer Comparer { get; }
 
+        /// <inheritdoc />
+        public override ValueComparer KeyComparer { get; }
+
+        public NpgsqlStringTypeMapping(
+            [NotNull] string storeType,
+            DbType dbType = System.Data.DbType.String,
+            bool unicode = false,
+            int? size = null)
+            : base(storeType, dbType, unicode, size)
+        {
+            if (storeType == "character" && dbType == System.Data.DbType.StringFixedLength)
+            {
+                Comparer = CharacterValueComparer;
+                KeyComparer = CharacterValueComparer;
+            }
+        }
+
+        /// <inheritdoc />
+        protected NpgsqlStringTypeMapping(
+            RelationalTypeMappingParameters parameters,
+            ValueComparer comparer,
+            ValueComparer keyComparer)
+            : base(parameters)
+        {
+            Comparer = comparer;
+            KeyComparer = keyComparer;
+        }
+
+        /// <inheritdoc />
         protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
-            => new NpgsqlStringTypeMapping(parameters);
+            => new NpgsqlStringTypeMapping(parameters, Comparer, KeyComparer);
 
+        /// <inheritdoc />
         protected override void ConfigureParameter(DbParameter parameter)
         {
+            if (parameter.DbType == System.Data.DbType.StringFixedLength)
+                parameter.Value = (parameter.Value as string)?.TrimEnd() ?? string.Empty;
+
             // See #357
             if (Size.HasValue)
             {

--- a/src/EFCore.PG/Storage/Internal/NpgsqlTypeMappingSource.cs
+++ b/src/EFCore.PG/Storage/Internal/NpgsqlTypeMappingSource.cs
@@ -65,9 +65,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
         // Character types
         readonly NpgsqlStringTypeMapping       _text               = new NpgsqlStringTypeMapping("text");
         readonly NpgsqlStringTypeMapping       _varchar            = new NpgsqlStringTypeMapping("character varying");
-        readonly NpgsqlStringTypeMapping       _char               = new NpgsqlStringTypeMapping("character", DbType.StringFixedLength);
+        readonly NpgsqlStringTypeMapping       _char               = new NpgsqlCharacterTypeMapping("character");
         readonly CharTypeMapping               _singleChar         = new CharTypeMapping("character(1)", DbType.String);
-        readonly NpgsqlStringTypeMapping       _stringAsSingleChar = new NpgsqlStringTypeMapping("character(1)");
+        readonly NpgsqlStringTypeMapping       _stringAsSingleChar = new NpgsqlCharacterTypeMapping("character(1)");
         readonly NpgsqlJsonbTypeMapping        _jsonb              = new NpgsqlJsonbTypeMapping();
         readonly NpgsqlJsonTypeMapping         _json               = new NpgsqlJsonTypeMapping();
         readonly NpgsqlXmlTypeMapping          _xml                = new NpgsqlXmlTypeMapping();

--- a/src/EFCore.PG/Storage/Internal/NpgsqlTypeMappingSource.cs
+++ b/src/EFCore.PG/Storage/Internal/NpgsqlTypeMappingSource.cs
@@ -65,7 +65,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
         // Character types
         readonly NpgsqlStringTypeMapping       _text               = new NpgsqlStringTypeMapping("text");
         readonly NpgsqlStringTypeMapping       _varchar            = new NpgsqlStringTypeMapping("character varying");
-        readonly NpgsqlStringTypeMapping       _char               = new NpgsqlStringTypeMapping("character");
+        readonly NpgsqlStringTypeMapping       _char               = new NpgsqlStringTypeMapping("character", DbType.StringFixedLength);
         readonly CharTypeMapping               _singleChar         = new CharTypeMapping("character(1)", DbType.String);
         readonly NpgsqlStringTypeMapping       _stringAsSingleChar = new NpgsqlStringTypeMapping("character(1)");
         readonly NpgsqlJsonbTypeMapping        _jsonb              = new NpgsqlJsonbTypeMapping();

--- a/test/EFCore.PG.FunctionalTests/Query/CharacterQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/CharacterQueryNpgsqlTest.cs
@@ -150,6 +150,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
 
         #region Fixture
 
+        // ReSharper disable once ClassNeverInstantiated.Global
         /// <summary>
         /// Represents a fixture suitable for testing character data.
         /// </summary>
@@ -257,14 +258,12 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
 
         #region Helpers
 
+        // ReSharper disable once UnusedMember.Global
         /// <summary>
         /// Asserts that the SQL fragment appears in the logs.
         /// </summary>
         /// <param name="sql">The SQL statement or fragment to search for in the logs.</param>
-        public void AssertContainsSql(string sql)
-        {
-            Assert.Contains(sql, Fixture.TestSqlLoggerFactory.Sql);
-        }
+        public void AssertContainsSql(string sql) => Assert.Contains(sql, Fixture.TestSqlLoggerFactory.Sql);
 
         #endregion
     }

--- a/test/EFCore.PG.FunctionalTests/Query/CharacterQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/CharacterQueryNpgsqlTest.cs
@@ -1,0 +1,271 @@
+﻿using System;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Npgsql.EntityFrameworkCore.PostgreSQL.TestUtilities;
+using Xunit;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
+{
+    public class CharacterQueryNpgsqlTest : IClassFixture<CharacterQueryNpgsqlTest.CharacterQueryNpgsqlFixture>
+    {
+        #region Tests
+
+        [Fact]
+        public void Find_in_database()
+        {
+            Fixture.ClearEntities();
+
+            // important: add here so they aren't locally available below.
+            using (var ctx = Fixture.CreateContext())
+            {
+                ctx.CharacterTestEntities.Add(new CharacterTestEntity { Character8 = "12345678" });
+                ctx.CharacterTestEntities.Add(new CharacterTestEntity { Character8 = "123456  " });
+                ctx.SaveChanges();
+            }
+
+            using (var ctx = Fixture.CreateContext())
+            {
+                const string update = "update";
+
+                var m1 = ctx.CharacterTestEntities.Find("12345678");
+                Assert.NotNull(m1);
+                m1.Character6 = update;
+                ctx.SaveChanges();
+
+                var m2 = ctx.CharacterTestEntities.Find("123456  ");
+                Assert.NotNull(m2);
+                m2.Character6 = update;
+                ctx.SaveChanges();
+
+                var item0 = ctx.CharacterTestEntities.Find("12345678").Character6;
+                Assert.Equal(update, item0);
+
+                var item1 = ctx.CharacterTestEntities.Find("123456  ").Character6;
+                Assert.Equal(update, item1);
+            }
+        }
+
+        [Fact]
+        public void Find_locally_available()
+        {
+            Fixture.ClearEntities();
+
+            // important: add here so they are locally available below.
+            using (var ctx = Fixture.CreateContext())
+            {
+                ctx.CharacterTestEntities.Add(new CharacterTestEntity { Character8 = "12345678" });
+                ctx.CharacterTestEntities.Add(new CharacterTestEntity { Character8 = "123456  " });
+                ctx.SaveChanges();
+
+                const string update = "update";
+
+                var m1 = ctx.CharacterTestEntities.Find("12345678");
+                m1.Character6 = update;
+                ctx.SaveChanges();
+
+                var m2 = ctx.CharacterTestEntities.Find("123456  ");
+                m2.Character6 = update;
+                ctx.SaveChanges();
+
+                var item0 = ctx.CharacterTestEntities.Find("12345678").Character6;
+                Assert.Equal(update, item0);
+
+                var item1 = ctx.CharacterTestEntities.Find("123456  ").Character6;
+                Assert.Equal(update, item1);
+            }
+        }
+
+        /// <summary>
+        /// Test something like: select '123456  '::char(8) = '123456'::char(8);
+        /// </summary>
+        [Fact]
+        public void Test_change_tracking()
+        {
+            Fixture.ClearEntities();
+
+            using (var ctx = Fixture.CreateContext())
+            {
+                const string update = "update";
+
+                ctx.CharacterTestEntities.Add(new CharacterTestEntity { Character8 = "12345678" });
+                ctx.CharacterTestEntities.Add(new CharacterTestEntity { Character8 = "123456  " });
+                ctx.SaveChanges();
+
+                var m1 = ctx.CharacterTestEntities.Find("12345678");
+                m1.Character6 = update;
+                ctx.SaveChanges();
+
+                var m2 = ctx.CharacterTestEntities.Find("123456  ");
+                m2.Character6 = update;
+                ctx.SaveChanges();
+            }
+        }
+
+        /// <summary>
+        /// Test that comparisons are treated correctly.
+        /// </summary>
+        [Fact]
+        public void Test_change_tracking_key_sizes()
+        {
+            Fixture.ClearEntities();
+
+            using (var ctx = Fixture.CreateContext())
+            {
+                var entity = new CharacterTestEntity { Character8 = "123456  ", Character6 = "12345 " };
+                ctx.CharacterTestEntities.Add(entity);
+                ctx.SaveChanges();
+
+                var update = ctx.CharacterTestEntities.Single(x => x.Character8 == "123456");
+                update.Character6 = entity.Character6.TrimEnd();
+                Assert.Equal(1, ctx.SaveChanges());
+
+                var test = ctx.CharacterTestEntities.Single(x => x.Character6 == "12345 ");
+                Assert.Equal("12345 ", test.Character6);
+            }
+        }
+
+        #endregion
+
+        #region Support
+
+        /// <summary>
+        /// Provides resources for unit tests.
+        /// </summary>
+        CharacterQueryNpgsqlFixture Fixture { get; }
+
+        /// <summary>
+        /// Initializes resources for unit tests.
+        /// </summary>
+        /// <param name="fixture">The fixture of resources for testing.</param>
+        public CharacterQueryNpgsqlTest(CharacterQueryNpgsqlFixture fixture)
+        {
+            Fixture = fixture;
+            Fixture.TestSqlLoggerFactory.Clear();
+        }
+
+        #endregion
+
+        #region Fixture
+
+        /// <summary>
+        /// Represents a fixture suitable for testing character data.
+        /// </summary>
+        public class CharacterQueryNpgsqlFixture : IDisposable
+        {
+            /// <summary>
+            /// The <see cref="NpgsqlTestStore"/> used for testing.
+            /// </summary>
+            private readonly NpgsqlTestStore _testStore;
+
+            /// <summary>
+            /// The <see cref="DbContextOptions"/> used for testing.
+            /// </summary>
+            private readonly DbContextOptions _options;
+
+            /// <summary>
+            /// The logger factory used for testing.
+            /// </summary>
+            public TestSqlLoggerFactory TestSqlLoggerFactory { get; }
+
+            /// <summary>
+            /// Initializes a <see cref="CharacterQueryNpgsqlTest.CharacterQueryNpgsqlFixture"/>.
+            /// </summary>
+            // ReSharper disable once UnusedMember.Global
+            public CharacterQueryNpgsqlFixture()
+            {
+                TestSqlLoggerFactory = new TestSqlLoggerFactory();
+
+                _testStore = NpgsqlTestStore.CreateScratch();
+
+                _options =
+                    new DbContextOptionsBuilder()
+                        .UseNpgsql(_testStore.ConnectionString, b => b.ApplyConfiguration())
+                        .UseInternalServiceProvider(
+                            new ServiceCollection()
+                                .AddEntityFrameworkNpgsql()
+                                .AddSingleton<ILoggerFactory>(TestSqlLoggerFactory)
+                                .BuildServiceProvider())
+                        .Options;
+
+                using (var context = CreateContext())
+                {
+                    context.Database.EnsureCreated();
+                }
+            }
+
+            /// <summary>
+            /// Creates a new <see cref="CharacterContext"/>.
+            /// </summary>
+            /// <returns>
+            /// A <see cref="CharacterContext"/> for testing.
+            /// </returns>
+            public CharacterContext CreateContext() => new CharacterContext(_options);
+
+            /// <summary>
+            /// Clears the entities in the context.
+            /// </summary>
+            public void ClearEntities()
+            {
+                using (var ctx = CreateContext())
+                {
+                    var entities = ctx.CharacterTestEntities.ToArray();
+
+                    foreach (var e in entities)
+                        ctx.CharacterTestEntities.Remove(e);
+
+                    ctx.SaveChanges();
+                }
+            }
+
+            /// <inheritdoc />
+            public void Dispose() => _testStore.Dispose();
+        }
+
+        public class CharacterTestEntity
+        {
+            public string Character8 { get; set; }
+            public string Character6 { get; set; }
+        }
+
+        public class CharacterContext : DbContext
+        {
+            public DbSet<CharacterTestEntity> CharacterTestEntities { get; set; }
+
+            /// <summary>
+            /// Initializes a <see cref="CharacterContext"/>.
+            /// </summary>
+            /// <param name="options">
+            /// The options to be used for configuration.
+            /// </param>
+            public CharacterContext(DbContextOptions options) : base(options) {}
+
+            /// <inheritdoc />
+            protected override void OnModelCreating(ModelBuilder builder)
+                => builder.Entity<CharacterTestEntity>(
+                    entity =>
+                    {
+                        entity.HasKey(e => e.Character8);
+                        entity.Property(e => e.Character8).HasColumnType("character(8)");
+                        entity.Property(e => e.Character6).HasColumnType("character(6)");
+                    });
+        }
+
+        #endregion
+
+        #region Helpers
+
+        /// <summary>
+        /// Asserts that the SQL fragment appears in the logs.
+        /// </summary>
+        /// <param name="sql">The SQL statement or fragment to search for in the logs.</param>
+        public void AssertContainsSql(string sql)
+        {
+            Assert.Contains(sql, Fixture.TestSqlLoggerFactory.Sql);
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
This is an attempt to patch #567 in which an exception is thrown due to a conflict between changes detected by the CLR and the number of records changed in the database.

The key here is to modify the way parameter values are compared in the CLR by overriding `Comparer` and `KeyComparer` with a `ValueComparer<string>` that uses PostgreSQL `character` semantics.

## Related
Fixes: #567 