### PR TITLE
Refactor DateTime member translator for plugins

### DIFF
--- a/src/EFCore.PG.NodaTime/NodaTimeMemberTranslator.cs
+++ b/src/EFCore.PG.NodaTime/NodaTimeMemberTranslator.cs
@@ -27,15 +27,18 @@ using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
-using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 using NodaTime;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime
 {
     /// <summary>
     /// Provides translation services for <see cref="NodaTime"/> members.
     /// </summary>
-    public class NodaTimeMemberTranslator : IMemberTranslator
+    /// <remarks>
+    /// See: https://www.postgresql.org/docs/current/static/functions-datetime.html
+    /// </remarks>
+    public class NodaTimeMemberTranslator : NpgsqlDateTimeMemberTranslator
     {
         /// <summary>
         /// The static member info for <see cref="T:SystemClock.Instance"/>.
@@ -44,8 +47,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime
             typeof(SystemClock).GetRuntimeProperty(nameof(SystemClock.Instance));
 
         /// <inheritdoc />
-        [CanBeNull]
-        public Expression Translate(MemberExpression e)
+        public override Expression Translate(MemberExpression e)
         {
             if (e.Member == Instance)
                 return e;
@@ -107,7 +109,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime
                 // Unlike DateTime.DayOfWeek, NodaTime's IsoDayOfWeek enum doesn't exactly correspond to PostgreSQL's
                 // values returned by DATE_PART('dow', ...): in NodaTime Sunday is 7 and not 0, which is None.
                 // So we generate a CASE WHEN expression to translate PostgreSQL's 0 to 7.
-                var getValueExpression = GetDatePartExpression(e, "dow");
+                var getValueExpression = GetDatePartExpression(e, "dow", true);
                 return
                     Expression.Condition(
                         Expression.Equal(
@@ -129,29 +131,6 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime
             default:
                 return null;
             }
-        }
-
-        /// <summary>
-        /// Constructs the DATE_PART expression.
-        /// </summary>
-        /// <param name="e">The member expression.</param>
-        /// <param name="partName">The name of the DATE_PART to construct.</param>
-        /// <param name="needsFloor">True if the result should be wrapped with FLOOR(...); otherwise, false.</param>
-        /// <returns>
-        /// The DATE_PART expression.
-        /// </returns>
-        [NotNull]
-        static Expression GetDatePartExpression([NotNull] MemberExpression e, [NotNull] string partName, bool needsFloor = false)
-        {
-            // DATE_PART returns doubles, which we floor and cast into ints
-            // This also gets rid of sub-second components when retrieving seconds
-
-            var result = new SqlFunctionExpression("DATE_PART", typeof(double), new[] { Expression.Constant(partName), e.Expression });
-
-            if (needsFloor)
-                result = new SqlFunctionExpression("FLOOR", typeof(double), new[] { result });
-
-            return new ExplicitCastExpression(result, typeof(int));
         }
     }
 }

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlDateTimeMemberTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlDateTimeMemberTranslator.cs
@@ -32,7 +32,7 @@ using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Query.Expressions.Internal;
 using NpgsqlTypes;
 
-namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Internal
 {
     /// <summary>
     /// Provides translation services for <see cref="DateTime"/> members.
@@ -140,7 +140,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators
         /// This also gets rid of sub-second components when retrieving seconds.
         /// </remarks>
         [NotNull]
-        protected static Expression GetDatePartExpression(
+        static Expression GetDatePartExpression(
             [NotNull] MemberExpression e,
             [NotNull] string partName,
             bool floor = false)

--- a/src/EFCore.PG/Query/ExpressionTranslators/NpgsqlDateTimeMemberTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/NpgsqlDateTimeMemberTranslator.cs
@@ -32,11 +32,14 @@ using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Query.Expressions.Internal;
 using NpgsqlTypes;
 
-namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Internal
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators
 {
     /// <summary>
     /// Provides translation services for <see cref="DateTime"/> members.
     /// </summary>
+    /// <remarks>
+    /// See: https://www.postgresql.org/docs/current/static/functions-datetime.html
+    /// </remarks>
     public class NpgsqlDateTimeMemberTranslator : IMemberTranslator
     {
         /// <summary>
@@ -85,14 +88,10 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Inte
 
             case nameof(DateTime.DayOfWeek):
                 // .NET's DayOfWeek is an enum, but its int values happen to correspond to PostgreSQL
-                return GetDatePartExpression(e, "dow");
+                return GetDatePartExpression(e, "dow", true);
 
             case nameof(DateTime.Date):
-                return new SqlFunctionExpression("DATE_TRUNC", e.Type, new[]
-                {
-                    Expression.Constant("day"),
-                    e.Expression
-                });
+                return new SqlFunctionExpression("DATE_TRUNC", e.Type, new[] { Expression.Constant("day"), e.Expression });
 
             case nameof(DateTime.TimeOfDay):
                 // TODO: Technically possible simply via casting to PG time,
@@ -111,30 +110,6 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Inte
         }
 
         /// <summary>
-        /// Constructs the DATE_PART expression.
-        /// </summary>
-        /// <param name="e">The member expression.</param>
-        /// <param name="partName">The name of the DATE_PART to construct.</param>
-        /// <returns>
-        /// The DATE_PART expression.
-        /// </returns>
-        [NotNull]
-        static Expression GetDatePartExpression([NotNull] MemberExpression e, [NotNull] string partName)
-            =>
-                // DATE_PART returns doubles, which we floor and cast into ints
-                // This also gets rid of sub-second components when retrieving seconds
-                new ExplicitCastExpression(
-                    new SqlFunctionExpression("FLOOR", typeof(double), new[]
-                    {
-                        new SqlFunctionExpression("DATE_PART", typeof(double), new[]
-                        {
-                            Expression.Constant(partName),
-                            e.Expression
-                        })
-                    }),
-                    typeof(int));
-
-        /// <summary>
         /// Translates static members of <see cref="DateTime"/>.
         /// </summary>
         /// <param name="e">The member expression.</param>
@@ -149,6 +124,34 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Inte
             if (e.Member.Equals(UtcNow))
                 return new AtTimeZoneExpression(new SqlFunctionExpression("NOW", e.Type), "UTC", e.Type);
             return null;
+        }
+
+        /// <summary>
+        /// Constructs the DATE_PART expression.
+        /// </summary>
+        /// <param name="e">The member expression.</param>
+        /// <param name="partName">The name of the DATE_PART to construct.</param>
+        /// <param name="floor">True if the result should be wrapped with FLOOR(...); otherwise, false.</param>
+        /// <returns>
+        /// The DATE_PART expression.
+        /// </returns>
+        /// <remarks>
+        /// DATE_PART returns doubles, which we floor and cast into ints
+        /// This also gets rid of sub-second components when retrieving seconds.
+        /// </remarks>
+        [NotNull]
+        protected static Expression GetDatePartExpression(
+            [NotNull] MemberExpression e,
+            [NotNull] string partName,
+            bool floor = false)
+        {
+            var result =
+                new SqlFunctionExpression("DATE_PART", typeof(double), new[] { Expression.Constant(partName), e.Expression });
+
+            if (floor)
+                result = new SqlFunctionExpression("FLOOR", typeof(double), new[] { result });
+
+            return new ExplicitCastExpression(result, typeof(int));
         }
     }
 }


### PR DESCRIPTION
Fixes: #576 

This PR moves the `NpgsqlDateTimeMemberTranslator` out of the Internal namespace so that it can be inherited in the NodaTime plugin so that both classes can share the same (updated) `GetDatePartExpression(...)`.