### PR TITLE
Translate DateTime.Today

### DIFF
--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlDateTimeMemberTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlDateTimeMemberTranslator.cs
@@ -52,6 +52,11 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Inte
         /// </summary>
         [NotNull] static readonly PropertyInfo UtcNow = typeof(DateTime).GetRuntimeProperty(nameof(DateTime.UtcNow));
 
+        /// <summary>
+        /// The static <see cref="PropertyInfo"/> for <see cref="T:DateTime.Today"/>.
+        /// </summary>
+        [NotNull] static readonly PropertyInfo Today = typeof(DateTime).GetRuntimeProperty(nameof(DateTime.Today));
+
         /// <inheritdoc />
         [CanBeNull]
         public virtual Expression Translate(MemberExpression e)
@@ -123,6 +128,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Inte
                 return new SqlFunctionExpression("NOW", e.Type);
             if (e.Member.Equals(UtcNow))
                 return new AtTimeZoneExpression(new SqlFunctionExpression("NOW", e.Type), "UTC", e.Type);
+            if (e.Member.Equals(Today))
+                return new SqlFunctionExpression("DATE_TRUNC", e.Type, new Expression[] { Expression.Constant("day"), new SqlFunctionExpression("NOW", e.Type) });
             return null;
         }
 

--- a/test/EFCore.PG.FunctionalTests/Query/SimpleQueryNpgsqlTest.Where.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/SimpleQueryNpgsqlTest.Where.cs
@@ -20,6 +20,12 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             AssertContainsSqlFragment("WHERE NOW() AT TIME ZONE 'UTC' <>");
         }
 
+        public override async Task Where_datetime_today(bool isAsync)
+        {
+            await base.Where_datetime_today(isAsync);
+            AssertContainsSqlFragment("WHERE DATE_TRUNC('day', NOW()) ");
+        }
+
         public override async Task Where_datetime_date_component(bool isAsync)
         {
             await base.Where_datetime_date_component(isAsync);


### PR DESCRIPTION
Queries with `DateTime.Today` used in-memory filtering.  I'm not sure I follow how these unit tests work. Let me know if I need to make any changes and I'll watch for CI errors. 

```c#
ctx.SomeEntity.Where(s => s.CreatedDate == DateTime.Today);
```

```sql
SELECT * 
FROM "SomemEntity" AS s 
WHERE s."CreatedDate" == DATE_TRUNC('date', NOW());
```