### PR TITLE
Update enum quoting and default schema use

### DIFF
--- a/src/EFCore.PG/Extensions/NpgsqlModelBuilderExtensions.cs
+++ b/src/EFCore.PG/Extensions/NpgsqlModelBuilderExtensions.cs
@@ -187,6 +187,9 @@ namespace Microsoft.EntityFrameworkCore
             Check.NotEmpty(name, nameof(name));
             Check.NotNull(labels, nameof(labels));
 
+            if (schema == null)
+                schema = modelBuilder.Model.FindAnnotation(RelationalAnnotationNames.DefaultSchema)?.Value as string;
+
             modelBuilder.Model.Npgsql().GetOrAddPostgresEnum(schema, name, labels);
             return modelBuilder;
         }

--- a/src/EFCore.PG/Extensions/NpgsqlModelBuilderExtensions.cs
+++ b/src/EFCore.PG/Extensions/NpgsqlModelBuilderExtensions.cs
@@ -187,9 +187,6 @@ namespace Microsoft.EntityFrameworkCore
             Check.NotEmpty(name, nameof(name));
             Check.NotNull(labels, nameof(labels));
 
-            if (schema == null)
-                schema = modelBuilder.Model.FindAnnotation(RelationalAnnotationNames.DefaultSchema)?.Value as string;
-
             modelBuilder.Model.Npgsql().GetOrAddPostgresEnum(schema, name, labels);
             return modelBuilder;
         }

--- a/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
@@ -279,11 +279,6 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations
 
             var type = operation.ColumnType ?? GetColumnType(operation.Schema, operation.Table, operation.Name, operation.ClrType, null, operation.MaxLength, false, model);
 
-            // User-defined type names are quoted if they contain uppercase letters. Other types are never quoted
-            // since users sometimes prefer to write TEXT instead of text.
-            if (_typeMappingSource.IsUserDefinedType(type))
-                type = _sqlGenerationHelper.DelimitIdentifier(type);
-
             string newSequenceName = null;
             var defaultValueSql = operation.DefaultValueSql;
 
@@ -944,11 +939,6 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations
 
             if (type == null)
                 type = GetColumnType(schema, table, name, clrType, unicode, maxLength, fixedLength, rowVersion, model);
-
-            // User-defined type names are quoted if they contain uppercase letters. Other types are never quoted
-            // since users sometimes prefer to write TEXT instead of text.
-            if (_typeMappingSource.IsUserDefinedType(type))
-                type = _sqlGenerationHelper.DelimitIdentifier(type);
 
             CheckForOldValueGenerationAnnotation(annotatable);
             var valueGenerationStrategy = annotatable[NpgsqlAnnotationNames.ValueGenerationStrategy] as NpgsqlValueGenerationStrategy?;

--- a/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
@@ -720,7 +720,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations
             [NotNull] IModel model,
             [NotNull] MigrationCommandListBuilder builder)
         {
-            var schema = enumType.Schema ?? model.FindAnnotation(RelationalAnnotationNames.DefaultSchema)?.Value as string;
+            var schema = GetSchemaOrDefault(enumType.Schema, model);
 
             // Schemas are normally created (or rather ensured) by the model differ, which scans all tables, sequences
             // and other database objects. However, it isn't aware of enums, so we always ensure schema on enum creation.
@@ -750,7 +750,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations
             [CanBeNull] IAnnotatable oldDatabase,
             [NotNull] MigrationCommandListBuilder builder)
         {
-            var schema = enumType.Schema ?? oldDatabase?.FindAnnotation(RelationalAnnotationNames.DefaultSchema)?.Value as string;
+            var schema = GetSchemaOrDefault(enumType.Schema, oldDatabase);
 
             builder
                 .Append("DROP TYPE ")
@@ -1117,6 +1117,10 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations
         #endregion Storage parameter utilities
 
         #region Helpers
+
+        [CanBeNull]
+        static string GetSchemaOrDefault([CanBeNull] string schema, [CanBeNull] IAnnotatable model)
+            => schema ?? model?.FindAnnotation(RelationalAnnotationNames.DefaultSchema)?.Value as string;
 
         /// <summary>
         /// True if <see cref="_postgresVersion"/> is null, greater than, or equal to the specified version.

--- a/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlEnumTypeMapping.cs
+++ b/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlEnumTypeMapping.cs
@@ -1,29 +1,4 @@
-﻿#region License
-
-// The PostgreSQL License
-//
-// Copyright (C) 2016 The Npgsql Development Team
-//
-// Permission to use, copy, modify, and distribute this software and its
-// documentation for any purpose, without fee, and without a written
-// agreement is hereby granted, provided that the above copyright notice
-// and this paragraph and the following two paragraphs appear in all copies.
-//
-// IN NO EVENT SHALL THE NPGSQL DEVELOPMENT TEAM BE LIABLE TO ANY PARTY
-// FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES,
-// INCLUDING LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS
-// DOCUMENTATION, EVEN IF THE NPGSQL DEVELOPMENT TEAM HAS BEEN ADVISED OF
-// THE POSSIBILITY OF SUCH DAMAGE.
-//
-// THE NPGSQL DEVELOPMENT TEAM SPECIFICALLY DISCLAIMS ANY WARRANTIES,
-// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-// AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS
-// ON AN "AS IS" BASIS, AND THE NPGSQL DEVELOPMENT TEAM HAS NO OBLIGATIONS
-// TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-
-#endregion
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;

--- a/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlEnumTypeMapping.cs
+++ b/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlEnumTypeMapping.cs
@@ -1,31 +1,91 @@
-﻿using System;
+﻿#region License
+
+// The PostgreSQL License
+//
+// Copyright (C) 2016 The Npgsql Development Team
+//
+// Permission to use, copy, modify, and distribute this software and its
+// documentation for any purpose, without fee, and without a written
+// agreement is hereby granted, provided that the above copyright notice
+// and this paragraph and the following two paragraphs appear in all copies.
+//
+// IN NO EVENT SHALL THE NPGSQL DEVELOPMENT TEAM BE LIABLE TO ANY PARTY
+// FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES,
+// INCLUDING LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS
+// DOCUMENTATION, EVEN IF THE NPGSQL DEVELOPMENT TEAM HAS BEEN ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//
+// THE NPGSQL DEVELOPMENT TEAM SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS
+// ON AN "AS IS" BASIS, AND THE NPGSQL DEVELOPMENT TEAM HAS NO OBLIGATIONS
+// TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
 {
     public class NpgsqlEnumTypeMapping : RelationalTypeMapping
     {
-        readonly NpgsqlSqlGenerationHelper _sqlGenerationHelper;
-        readonly INpgsqlNameTranslator _nameTranslator;
+        [NotNull] static readonly NpgsqlSqlGenerationHelper SqlGenerationHelper =
+            new NpgsqlSqlGenerationHelper(new RelationalSqlGenerationHelperDependencies());
 
-        public NpgsqlEnumTypeMapping(string storeType, Type enumType, INpgsqlNameTranslator nameTranslator)
+        [NotNull] readonly INpgsqlNameTranslator _nameTranslator;
+
+        [CanBeNull] readonly string _storeTypeSchema;
+
+        /// <summary>
+        /// Translates the CLR member value to the PostgreSQL value label.
+        /// </summary>
+        [NotNull] readonly Dictionary<object, string> _members;
+
+        [NotNull]
+        public override string StoreType => SqlGenerationHelper.DelimitIdentifier(base.StoreType, _storeTypeSchema);
+
+        public NpgsqlEnumTypeMapping(
+            [NotNull] string storeType,
+            [CanBeNull] string storeTypeSchema,
+            [NotNull] Type enumType,
+            [CanBeNull] INpgsqlNameTranslator nameTranslator = null)
             : base(storeType, enumType)
         {
+            if (!enumType.IsEnum || !enumType.IsValueType)
+                throw new ArgumentException($"Enum type mappings require a CLR enum. {enumType.FullName} is not an enum.");
+
+            if (nameTranslator == null)
+                nameTranslator = NpgsqlConnection.GlobalTypeMapper.DefaultNameTranslator;
+
             _nameTranslator = nameTranslator;
-            _sqlGenerationHelper = new NpgsqlSqlGenerationHelper(new RelationalSqlGenerationHelperDependencies());
+            _storeTypeSchema = storeTypeSchema;
+            _members = CreateValueMapping(enumType, nameTranslator);
         }
 
-        protected NpgsqlEnumTypeMapping(RelationalTypeMappingParameters parameters, INpgsqlNameTranslator nameTranslator)
+        protected NpgsqlEnumTypeMapping(
+            RelationalTypeMappingParameters parameters,
+            [CanBeNull] string storeTypeSchema,
+            [NotNull] INpgsqlNameTranslator nameTranslator)
             : base(parameters)
         {
             _nameTranslator = nameTranslator;
-            _sqlGenerationHelper = new NpgsqlSqlGenerationHelper(new RelationalSqlGenerationHelperDependencies());
+            _storeTypeSchema = storeTypeSchema;
+            _members = CreateValueMapping(parameters.CoreParameters.ClrType, nameTranslator);
         }
 
         protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
-            => new NpgsqlEnumTypeMapping(parameters, _nameTranslator);
+            => new NpgsqlEnumTypeMapping(parameters, _storeTypeSchema, _nameTranslator);
 
-        protected override string GenerateNonNullSqlLiteral(object value)
-            => $"'{_nameTranslator.TranslateMemberName(value.ToString())}'::{_sqlGenerationHelper.DelimitIdentifier(StoreType)}";
+        protected override string GenerateNonNullSqlLiteral(object value) => $"'{_members[value]}'::{StoreType}";
+
+        [NotNull]
+        static Dictionary<object, string> CreateValueMapping([NotNull] Type enumType, [NotNull] INpgsqlNameTranslator nameTranslator)
+            => Enum.GetValues(enumType)
+                   .Cast<object>()
+                   .ToDictionary(x => x, x => nameTranslator.TranslateMemberName(Enum.GetName(enumType, x)));
     }
 }

--- a/test/EFCore.PG.FunctionalTests/Query/EnumQueryTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/EnumQueryTest.cs
@@ -36,7 +36,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             {
                 var x = ctx.SomeEntities.Single(e => e.MappedEnum == MappedEnum.Sad);
                 Assert.Equal(MappedEnum.Sad, x.MappedEnum);
-                AssertContainsInSql("WHERE e.\"MappedEnum\" = 'sad'::mapped_enum");
+                AssertContainsInSql("WHERE e.\"MappedEnum\" = 'sad'::test.mapped_enum");
             }
         }
 
@@ -132,8 +132,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
 
             static EnumContext()
             {
-                NpgsqlConnection.GlobalTypeMapper.MapEnum<MappedEnum>();
-                NpgsqlConnection.GlobalTypeMapper.MapEnum<InferredEnum>();
+                NpgsqlConnection.GlobalTypeMapper.MapEnum<MappedEnum>("test.mapped_enum");
+                NpgsqlConnection.GlobalTypeMapper.MapEnum<InferredEnum>("test.inferred_enum");
                 NpgsqlConnection.GlobalTypeMapper.MapEnum<SchemaQualifiedEnum>("test.schema_qualified_enum");
             }
 

--- a/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingTest.cs
+++ b/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingTest.cs
@@ -267,14 +267,14 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage
         [Fact]
         public void GenerateSqlLiteral_returns_enum_literal()
         {
-            var mapping = new NpgsqlEnumTypeMapping("dummy_enum", typeof(DummyEnum), new NpgsqlSnakeCaseNameTranslator());
+            var mapping = new NpgsqlEnumTypeMapping("dummy_enum", null, typeof(DummyEnum), new NpgsqlSnakeCaseNameTranslator());
             Assert.Equal("'sad'::dummy_enum", mapping.GenerateSqlLiteral(DummyEnum.Sad));
         }
 
         [Fact]
         public void GenerateSqlLiteral_returns_enum_uppercase_literal()
         {
-            var mapping = new NpgsqlEnumTypeMapping("DummyEnum", typeof(DummyEnum), new NpgsqlSnakeCaseNameTranslator());
+            var mapping = new NpgsqlEnumTypeMapping("DummyEnum", null, typeof(DummyEnum), new NpgsqlSnakeCaseNameTranslator());
             Assert.Equal("'sad'::\"DummyEnum\"", mapping.GenerateSqlLiteral(DummyEnum.Sad));
         }
 


### PR DESCRIPTION
## Changes
- If no schema is specified in `.ForNpgsqlHasEnum(...)`, then use the default schema annotation.
- Properly quote schema-qualified enums for literal generation and mapping (override `StoreType`).
- Cache mappings from CLR values to PostgreSQL labels.

Fixes: #554 
Fixes: #593 