### PR TITLE
Support user-defined ranges

### DIFF
--- a/doc/mapping/range.md
+++ b/doc/mapping/range.md
@@ -33,6 +33,7 @@ This allows you to have properties of type `NpgsqlRange<float>`, which will be m
 
 The above does *not* create the `floatrange` type for you. In order to do that, include the following in your context's `OnModelCreating()`:
 
+```c#
 protected override void OnModelCreating(ModelBuilder builder) {
     builder.ForNpgsqlHasRange("floatrange", "real");
 }

--- a/doc/mapping/range.md
+++ b/doc/mapping/range.md
@@ -1,8 +1,6 @@
 # Range Type Mapping
 
-PostgreSQL has the unique feature of supporting [*range data types*](https://www.postgresql.org/docs/current/static/rangetypes.html). Ranges represent a range of numbers, dates or other data types, and allow you to easily query ranges which contain a value, perform set operations (e.g. query ranges which contain other ranges), and other similar operations. The range operations supported by PostgreSQL are listed [in this page](https://www.postgresql.org/docs/current/static/functions-range.html). Starting with version 2.1, the Npgsql EF Core provider allows you to seemlessly map PostgreSQL's built-in ranges, and even perform operations on them.
-
-Note that user-defined ranges are not supported.
+PostgreSQL has the unique feature of supporting [*range data types*](https://www.postgresql.org/docs/current/static/rangetypes.html). Ranges represent a range of numbers, dates or other data types, and allow you to easily query ranges which contain a value, perform set operations (e.g. query ranges which contain other ranges), and other similar operations. The range operations supported by PostgreSQL are listed [in this page](https://www.postgresql.org/docs/current/static/functions-range.html). Starting with version 2.1, the Npgsql EF Core provider allows you to seemlessly map PostgreSQL's built-in ranges, and even perform operations on them. Version 2.2 added support for user-defined ranges.
 
 # Mapping ranges
 
@@ -18,6 +16,29 @@ public class Event
 ```
 
 This will create a column of type `daterange` in your database. You can similarly have properties of type `NpgsqlRange<int>`, `NpgsqlRange<long>`, etc.
+
+# User-defined ranges
+
+PostgreSQL comes with 6 built-in ranges: `int4range`, `int8range`, `numrange`, `tsrange`, `tstzrange`, `daterange`; these can be used simply by adding the appropriate `NpgsqlRange<T>` property in your entities as shown above. However, you can also define your own range types over arbitrary types, and use those in EF Core as well.
+
+To make the EF Core type mapper aware of your user-defined range, call the `MapRange()` method in your context's `OnConfiguring()` method as follows:
+```c#
+protected override void OnConfiguring(DbContextOptionsBuilder builder)
+{
+    builder.UseNpgsql("...", b => b.MapRange("floatrange", typeof(float)));
+}
+```
+
+This allows you to have properties of type `NpgsqlRange<float>`, which will be mapped to PostgreSQL `floatrange`.
+
+The above does *not* create the `floatrange` type for you. In order to do that, include the following in your context's `OnModelCreating()`:
+
+protected override void OnModelCreating(ModelBuilder builder) {
+    builder.ForNpgsqlHasRange("floatrange", "real");
+}
+```
+
+This will cause the appropriate [`CREATE TYPE ... AS RANGE`](https://www.postgresql.org/docs/current/static/sql-createtype.html) statement to be generated in your migrations, ensuring that your range is created and ready for use. Note that `ForNpgsqlHasRange()` supports additional parameters as supported by PostgreSQL `CREATE TYPE`.
 
 # Operation translation
 

--- a/doc/release-notes/2.2.md
+++ b/doc/release-notes/2.2.md
@@ -1,0 +1,10 @@
+# 2.2 Release Notes
+
+## New Features
+
+Aside from general EF Core features new in 2.2.0, the Npgsql provider contains the following major new features:
+
+* Support for PostgreSQL user-defined ranges. [See the documentation for more details](../mapping/range.md).
+
+## Breaking changes
+

--- a/doc/toc.md
+++ b/doc/toc.md
@@ -1,5 +1,6 @@
 ﻿# [Getting Started](index.md)
 # Release Notes
+## [2.2](release-notes/2.2.md)
 ## [2.1](release-notes/2.1.md)
 ## [2.0](release-notes/2.0.md)
 ## [1.1](release-notes/1.1.md)

--- a/src/EFCore.PG.NodaTime/NodaTimePlugin.cs
+++ b/src/EFCore.PG.NodaTime/NodaTimePlugin.cs
@@ -56,12 +56,12 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime
         [NotNull] readonly TimeTzMapping _timetz = new TimeTzMapping();
         [NotNull] readonly IntervalMapping _period = new IntervalMapping();
 
-        [NotNull] readonly NpgsqlRangeTypeMapping<LocalDateTime> _timestampLocalDateTimeRange;
-        [NotNull] readonly NpgsqlRangeTypeMapping<Instant> _timestampInstantRange;
-        [NotNull] readonly NpgsqlRangeTypeMapping<Instant> _timestamptzInstantRange;
-        [NotNull] readonly NpgsqlRangeTypeMapping<ZonedDateTime> _timestamptzZonedDateTimeRange;
-        [NotNull] readonly NpgsqlRangeTypeMapping<OffsetDateTime> _timestamptzOffsetDateTimeRange;
-        [NotNull] readonly NpgsqlRangeTypeMapping<LocalDate> _dateRange;
+        [NotNull] readonly NpgsqlRangeTypeMapping _timestampLocalDateTimeRange;
+        [NotNull] readonly NpgsqlRangeTypeMapping _timestampInstantRange;
+        [NotNull] readonly NpgsqlRangeTypeMapping _timestamptzInstantRange;
+        [NotNull] readonly NpgsqlRangeTypeMapping _timestamptzZonedDateTimeRange;
+        [NotNull] readonly NpgsqlRangeTypeMapping _timestamptzOffsetDateTimeRange;
+        [NotNull] readonly NpgsqlRangeTypeMapping _dateRange;
 
         #endregion
 
@@ -91,23 +91,12 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime
         /// </summary>
         public NodaTimePlugin()
         {
-            _timestampLocalDateTimeRange = new NpgsqlRangeTypeMapping<LocalDateTime>(
-                "tsrange", typeof(NpgsqlRange<LocalDateTime>), _timestampLocalDateTime, NpgsqlDbType.Range | NpgsqlDbType.Timestamp);
-
-            _timestampInstantRange = new NpgsqlRangeTypeMapping<Instant>(
-                "tsrange", typeof(NpgsqlRange<Instant>), _timestampInstant, NpgsqlDbType.Range | NpgsqlDbType.Timestamp);
-
-            _timestamptzInstantRange = new NpgsqlRangeTypeMapping<Instant>(
-                "tstzrange", typeof(NpgsqlRange<Instant>), _timestamptzInstant, NpgsqlDbType.Range | NpgsqlDbType.TimestampTz);
-
-            _timestamptzZonedDateTimeRange = new NpgsqlRangeTypeMapping<ZonedDateTime>(
-                "tstzrange", typeof(NpgsqlRange<ZonedDateTime>), _timestamptzZonedDateTime, NpgsqlDbType.Range | NpgsqlDbType.TimestampTz);
-
-            _timestamptzOffsetDateTimeRange = new NpgsqlRangeTypeMapping<OffsetDateTime>(
-                "tstzrange", typeof(NpgsqlRange<OffsetDateTime>), _timestamptzOffsetDateTime, NpgsqlDbType.Range | NpgsqlDbType.TimestampTz);
-
-            _dateRange = new NpgsqlRangeTypeMapping<LocalDate>(
-                "daterange", typeof(NpgsqlRange<LocalDate>), _date, NpgsqlDbType.Range | NpgsqlDbType.Date);
+            _timestampLocalDateTimeRange = new NpgsqlRangeTypeMapping("tsrange", typeof(NpgsqlRange<LocalDateTime>), _timestampLocalDateTime);
+            _timestampInstantRange = new NpgsqlRangeTypeMapping("tsrange", typeof(NpgsqlRange<Instant>), _timestampInstant);
+            _timestamptzInstantRange = new NpgsqlRangeTypeMapping("tstzrange", typeof(NpgsqlRange<Instant>), _timestamptzInstant);
+            _timestamptzZonedDateTimeRange = new NpgsqlRangeTypeMapping("tstzrange", typeof(NpgsqlRange<ZonedDateTime>), _timestamptzZonedDateTime);
+            _timestamptzOffsetDateTimeRange = new NpgsqlRangeTypeMapping("tstzrange", typeof(NpgsqlRange<OffsetDateTime>), _timestamptzOffsetDateTime);
+            _dateRange = new NpgsqlRangeTypeMapping("daterange", typeof(NpgsqlRange<LocalDate>), _date);
         }
 
         /// <inheritdoc />

--- a/src/EFCore.PG/Extensions/NpgsqlModelBuilderExtensions.cs
+++ b/src/EFCore.PG/Extensions/NpgsqlModelBuilderExtensions.cs
@@ -178,6 +178,61 @@ namespace Microsoft.EntityFrameworkCore
             return modelBuilder;
         }
 
+        /// <summary>
+        /// Registers a user-defined range type in the model.
+        /// </summary>
+        /// <param name="modelBuilder">The model builder on which to create the range type.</param>
+        /// <param name="schema">The schema in which to create the range type.</param>
+        /// <param name="name">The name of the range type to be created.</param>
+        /// <param name="subtype">The subtype (or element type) of the range</param>
+        /// <param name="canonicalFunction">
+        /// An optional PostgreSQL function which converts range values to a canonical form.
+        /// </param>
+        /// <param name="subtypeOpClass">Used to specify a non-default operator class.</param>
+        /// <param name="collation">Used to specify a non-default collation in the range's order.</param>
+        /// <param name="subtypeDiff">
+        /// An optional PostgreSQL function taking two values of the subtype type as argument, and return a double
+        /// precision value representing the difference between the two given values.
+        /// </param>
+        /// <remarks>
+        /// See https://www.postgresql.org/docs/current/static/rangetypes.html,
+        /// https://www.postgresql.org/docs/current/static/sql-createtype.html,
+        /// </remarks>
+        public static ModelBuilder ForNpgsqlHasRange(
+            [NotNull] this ModelBuilder modelBuilder,
+            [CanBeNull] string schema,
+            [NotNull] string name,
+            [NotNull] string subtype,
+            string canonicalFunction = null,
+            string subtypeOpClass = null,
+            string collation = null,
+            string subtypeDiff = null)
+        {
+            Check.NotNull(modelBuilder, nameof(modelBuilder));
+            Check.NotEmpty(name, nameof(name));
+            Check.NotEmpty(subtype, nameof(subtype));
+
+            modelBuilder.Model.Npgsql().GetOrAddPostgresRange(schema, name, subtype, canonicalFunction, subtypeOpClass,
+                collation, subtypeDiff);
+            return modelBuilder;
+        }
+
+        /// <summary>
+        /// Registers a user-defined range type in the model.
+        /// </summary>
+        /// <param name="modelBuilder">The model builder on which to create the range type.</param>
+        /// <param name="name">The name of the range type to be created.</param>
+        /// <param name="subtype">The subtype (or element type) of the range</param>
+        /// <remarks>
+        /// See https://www.postgresql.org/docs/current/static/rangetypes.html,
+        /// https://www.postgresql.org/docs/current/static/sql-createtype.html,
+        /// </remarks>
+        public static ModelBuilder ForNpgsqlHasRange(
+            [NotNull] this ModelBuilder modelBuilder,
+            [NotNull] string name,
+            [NotNull] string subtype)
+            => ForNpgsqlHasRange(modelBuilder, null, name, subtype);
+
         public static ModelBuilder ForNpgsqlUseTablespace(
             [NotNull] this ModelBuilder modelBuilder,
             [NotNull] string tablespace)

--- a/src/EFCore.PG/Extensions/NpgsqlModelBuilderExtensions.cs
+++ b/src/EFCore.PG/Extensions/NpgsqlModelBuilderExtensions.cs
@@ -198,6 +198,7 @@ namespace Microsoft.EntityFrameworkCore
         /// See https://www.postgresql.org/docs/current/static/rangetypes.html,
         /// https://www.postgresql.org/docs/current/static/sql-createtype.html,
         /// </remarks>
+        [NotNull]
         public static ModelBuilder ForNpgsqlHasRange(
             [NotNull] this ModelBuilder modelBuilder,
             [CanBeNull] string schema,
@@ -212,8 +213,14 @@ namespace Microsoft.EntityFrameworkCore
             Check.NotEmpty(name, nameof(name));
             Check.NotEmpty(subtype, nameof(subtype));
 
-            modelBuilder.Model.Npgsql().GetOrAddPostgresRange(schema, name, subtype, canonicalFunction, subtypeOpClass,
-                collation, subtypeDiff);
+            modelBuilder.Model.Npgsql().GetOrAddPostgresRange(
+                schema,
+                name,
+                subtype,
+                canonicalFunction,
+                subtypeOpClass,
+                collation,
+                subtypeDiff);
             return modelBuilder;
         }
 

--- a/src/EFCore.PG/Infrastructure/Internal/INpgsqlOptions.cs
+++ b/src/EFCore.PG/Infrastructure/Internal/INpgsqlOptions.cs
@@ -50,7 +50,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal
         /// The collection of range mappings.
         /// </summary>
         [NotNull]
-        IReadOnlyList<(Type ElementClrType, string RangeName, string SubTypeName)> RangeMappings { get; }
+        IReadOnlyList<(string RangeName, Type ElementClrType, string SubTypeName)> RangeMappings { get; }
 
         /// <summary>
         /// The collection of database plugins.

--- a/src/EFCore.PG/Infrastructure/Internal/INpgsqlOptions.cs
+++ b/src/EFCore.PG/Infrastructure/Internal/INpgsqlOptions.cs
@@ -47,6 +47,12 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal
         bool ReverseNullOrderingEnabled { get; }
 
         /// <summary>
+        /// The collection of range mappings.
+        /// </summary>
+        [NotNull]
+        IReadOnlyList<(Type ElementClrType, string RangeName, string SubTypeName)> RangeMappings { get; }
+
+        /// <summary>
         /// The collection of database plugins.
         /// </summary>
         [NotNull]

--- a/src/EFCore.PG/Infrastructure/Internal/INpgsqlOptions.cs
+++ b/src/EFCore.PG/Infrastructure/Internal/INpgsqlOptions.cs
@@ -50,7 +50,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal
         /// The collection of range mappings.
         /// </summary>
         [NotNull]
-        IReadOnlyList<(string RangeName, Type ElementClrType, string SubTypeName)> RangeMappings { get; }
+        IReadOnlyList<RangeMappingInfo> RangeMappings { get; }
 
         /// <summary>
         /// The collection of database plugins.

--- a/src/EFCore.PG/Infrastructure/Internal/NpgsqlOptionsExtension.cs
+++ b/src/EFCore.PG/Infrastructure/Internal/NpgsqlOptionsExtension.cs
@@ -131,8 +131,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal
         /// Returns a copy of the current instance configured with the specified range mapping.
         /// </summary>
         [NotNull]
-        internal virtual NpgsqlOptionsExtension WithRangeMapping(string rangeName, Type elementClrType,
-            string subtypeName)
+        internal virtual NpgsqlOptionsExtension WithRangeMapping(string rangeName, Type elementClrType, string subtypeName)
         {
             var clone = (NpgsqlOptionsExtension)Clone();
 

--- a/src/EFCore.PG/Infrastructure/Internal/NpgsqlOptionsExtension.cs
+++ b/src/EFCore.PG/Infrastructure/Internal/NpgsqlOptionsExtension.cs
@@ -30,6 +30,7 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Utilities;
+using NpgsqlTypes;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal
 {
@@ -38,7 +39,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal
     /// </summary>
     public class NpgsqlOptionsExtension : RelationalOptionsExtension
     {
-        [NotNull] readonly List<(string RangeName, Type ElementClrType, string SubTypeName)> _rangeMappings;
+        [NotNull] readonly List<RangeMappingInfo> _rangeMappings;
 
         [NotNull] readonly List<NpgsqlEntityFrameworkPlugin> _plugins;
 
@@ -58,7 +59,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal
         /// The list of range mappings specified by the user.
         /// </summary>
         [NotNull]
-        public IReadOnlyList<(string RangeName, Type ElementClrType, string SubTypeName)> RangeMappings => _rangeMappings;
+        public IReadOnlyList<RangeMappingInfo> RangeMappings => _rangeMappings;
 
         /// <summary>
         /// The collection of database plugins.
@@ -89,7 +90,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal
         /// </summary>
         public NpgsqlOptionsExtension()
         {
-            _rangeMappings = new List<(string RangeName, Type ElementClrType, string SubTypeName)>();
+            _rangeMappings = new List<RangeMappingInfo>();
             _plugins = new List<NpgsqlEntityFrameworkPlugin>();
         }
 
@@ -101,7 +102,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal
         public NpgsqlOptionsExtension([NotNull] NpgsqlOptionsExtension copyFrom) : base(copyFrom)
         {
             AdminDatabase = copyFrom.AdminDatabase;
-            _rangeMappings = new List<(string RangeName, Type ElementClrType, string SubTypeName)>(copyFrom._rangeMappings);
+            _rangeMappings = new List<RangeMappingInfo>(copyFrom._rangeMappings);
             _plugins = new List<NpgsqlEntityFrameworkPlugin>(copyFrom._plugins);
             PostgresVersion = copyFrom.PostgresVersion;
             ProvideClientCertificatesCallback = copyFrom.ProvideClientCertificatesCallback;
@@ -131,11 +132,24 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal
         /// Returns a copy of the current instance configured with the specified range mapping.
         /// </summary>
         [NotNull]
-        internal virtual NpgsqlOptionsExtension WithRangeMapping(string rangeName, Type elementClrType, string subtypeName)
+        public virtual NpgsqlOptionsExtension WithRangeMapping<TSubtype>(string rangeName, string subtypeName)
         {
             var clone = (NpgsqlOptionsExtension)Clone();
 
-            clone._rangeMappings.Add((rangeName, elementClrType, subtypeName));
+            clone._rangeMappings.Add(new RangeMappingInfo(rangeName, typeof(TSubtype), subtypeName));
+
+            return clone;
+        }
+
+        /// <summary>
+        /// Returns a copy of the current instance configured with the specified range mapping.
+        /// </summary>
+        [NotNull]
+        public virtual NpgsqlOptionsExtension WithRangeMapping(string rangeName, Type subtypeClrType, string subtypeName)
+        {
+            var clone = (NpgsqlOptionsExtension)Clone();
+
+            clone._rangeMappings.Add(new RangeMappingInfo(rangeName, subtypeClrType, subtypeName));
 
             return clone;
         }
@@ -232,5 +246,35 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal
         }
 
         #endregion Authentication
+    }
+
+    public readonly struct RangeMappingInfo
+    {
+        /// <summary>The name of the PostgreSQL range type to be mapped.</summary>
+        public readonly string RangeName;
+        /// <summary>
+        /// The CLR type of the range's subtype (or element).
+        /// The actual mapped type will be an <see cref="NpgsqlRange{T}"/> over this type.
+        /// </summary>
+        public readonly Type SubtypeClrType;
+        /// <summary>
+        /// Optionally, the name of the range's PostgreSQL subtype (or element).
+        /// This is usually not needed - the subtype will be inferred based on <see cref="SubtypeClrType"/>.
+        /// </summary>
+        public readonly string SubtypeName;
+
+        public RangeMappingInfo(string rangeName, Type subtypeClrType, string subtypeName)
+        {
+            RangeName = rangeName;
+            SubtypeClrType = subtypeClrType;
+            SubtypeName = subtypeName;
+        }
+
+        public void Deconstruct(out string rangeName, out Type subtypeClrType, out string subtypeName)
+        {
+            rangeName = RangeName;
+            subtypeClrType = SubtypeClrType;
+            subtypeName = SubtypeName;
+        }
     }
 }

--- a/src/EFCore.PG/Infrastructure/Internal/NpgsqlOptionsExtension.cs
+++ b/src/EFCore.PG/Infrastructure/Internal/NpgsqlOptionsExtension.cs
@@ -251,17 +251,17 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal
     public readonly struct RangeMappingInfo
     {
         /// <summary>The name of the PostgreSQL range type to be mapped.</summary>
-        public readonly string RangeName;
+        public string RangeName { get; }
         /// <summary>
         /// The CLR type of the range's subtype (or element).
         /// The actual mapped type will be an <see cref="NpgsqlRange{T}"/> over this type.
         /// </summary>
-        public readonly Type SubtypeClrType;
+        public Type SubtypeClrType { get; }
         /// <summary>
         /// Optionally, the name of the range's PostgreSQL subtype (or element).
         /// This is usually not needed - the subtype will be inferred based on <see cref="SubtypeClrType"/>.
         /// </summary>
-        public readonly string SubtypeName;
+        public string SubtypeName { get; }
 
         public RangeMappingInfo(string rangeName, Type subtypeClrType, string subtypeName)
         {

--- a/src/EFCore.PG/Infrastructure/Internal/NpgsqlOptionsExtension.cs
+++ b/src/EFCore.PG/Infrastructure/Internal/NpgsqlOptionsExtension.cs
@@ -38,7 +38,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal
     /// </summary>
     public class NpgsqlOptionsExtension : RelationalOptionsExtension
     {
-        [NotNull] readonly List<(Type ElementClrType, string RangeName, string SubTypeName)> _rangeMappings;
+        [NotNull] readonly List<(string RangeName, Type ElementClrType, string SubTypeName)> _rangeMappings;
 
         [NotNull] readonly List<NpgsqlEntityFrameworkPlugin> _plugins;
 
@@ -58,7 +58,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal
         /// The list of range mappings specified by the user.
         /// </summary>
         [NotNull]
-        public List<(Type ElementClrType, string RangeName, string SubTypeName)> RangeMappings => _rangeMappings;
+        public IReadOnlyList<(string RangeName, Type ElementClrType, string SubTypeName)> RangeMappings => _rangeMappings;
 
         /// <summary>
         /// The collection of database plugins.
@@ -89,7 +89,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal
         /// </summary>
         public NpgsqlOptionsExtension()
         {
-            _rangeMappings = new List<(Type ElementClrType, string RangeName, string SubTypeName)>();
+            _rangeMappings = new List<(string RangeName, Type ElementClrType, string SubTypeName)>();
             _plugins = new List<NpgsqlEntityFrameworkPlugin>();
         }
 
@@ -101,7 +101,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal
         public NpgsqlOptionsExtension([NotNull] NpgsqlOptionsExtension copyFrom) : base(copyFrom)
         {
             AdminDatabase = copyFrom.AdminDatabase;
-            _rangeMappings = new List<(Type ElementClrType, string RangeName, string SubTypeName)>(copyFrom._rangeMappings);
+            _rangeMappings = new List<(string RangeName, Type ElementClrType, string SubTypeName)>(copyFrom._rangeMappings);
             _plugins = new List<NpgsqlEntityFrameworkPlugin>(copyFrom._plugins);
             PostgresVersion = copyFrom.PostgresVersion;
             ProvideClientCertificatesCallback = copyFrom.ProvideClientCertificatesCallback;
@@ -131,11 +131,12 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal
         /// Returns a copy of the current instance configured with the specified range mapping.
         /// </summary>
         [NotNull]
-        internal virtual NpgsqlOptionsExtension WithRangeMapping(Type elementClrType, string rangeName, string subtypeName)
+        internal virtual NpgsqlOptionsExtension WithRangeMapping(string rangeName, Type elementClrType,
+            string subtypeName)
         {
             var clone = (NpgsqlOptionsExtension)Clone();
 
-            clone.RangeMappings.Add((elementClrType, rangeName, subtypeName));
+            clone._rangeMappings.Add((rangeName, elementClrType, subtypeName));
 
             return clone;
         }

--- a/src/EFCore.PG/Infrastructure/NpgsqlDbContextOptionsBuilder.cs
+++ b/src/EFCore.PG/Infrastructure/NpgsqlDbContextOptionsBuilder.cs
@@ -71,20 +71,21 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure
         /// <summary>
         /// Maps a user-defined PostgreSQL range type for use with all DbContexts.
         /// </summary>
-        /// <param name="elementClrType">
-        /// The CLR type of the range's element. The actual mapped type will be an <code>NpgsqlRange{T}</code> over
-        /// this type.
-        /// </param>
         /// <param name="rangeName">The name of the PostgreSQL range type to be mapped.</param>
+        /// <param name="elementClrType">
+        ///     The CLR type of the range's element. The actual mapped type will be an <code>NpgsqlRange{T}</code> over
+        ///     this type.
+        /// </param>
         /// <param name="subtypeName">
-        /// Optionally, the name of the range's subtype or element. This is usually not needed - the subtype will be
-        /// inferred based on <paramref name="elementClrType"/></param>
+        ///     Optionally, the name of the range's subtype or element. This is usually not needed - the subtype will be
+        ///     inferred based on <paramref name="elementClrType"/></param>
         /// <example>
         /// To map a range of PostgreSQL real, use the following:
         /// <code>NpgsqlTypeMappingSource.MapRange("real", typeof(float));</code>
         /// </example>
-        public virtual void MapRange(Type elementClrType, string rangeName, string subtypeName=null)
-            => WithOption(e => e.WithRangeMapping(elementClrType, rangeName, subtypeName));
+        public virtual void MapRange([NotNull] string rangeName, [NotNull] Type elementClrType,
+            string subtypeName = null)
+            => WithOption(e => e.WithRangeMapping(rangeName, elementClrType, subtypeName));
 
         /// <summary>
         /// Appends NULLS FIRST to all ORDER BY clauses. This is important for the tests which were written

--- a/src/EFCore.PG/Infrastructure/NpgsqlDbContextOptionsBuilder.cs
+++ b/src/EFCore.PG/Infrastructure/NpgsqlDbContextOptionsBuilder.cs
@@ -73,18 +73,17 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure
         /// </summary>
         /// <param name="rangeName">The name of the PostgreSQL range type to be mapped.</param>
         /// <param name="elementClrType">
-        ///     The CLR type of the range's element. The actual mapped type will be an <code>NpgsqlRange{T}</code> over
-        ///     this type.
+        /// The CLR type of the range's element. The actual mapped type will be an <code>NpgsqlRange{T}</code> over
+        /// this type.
         /// </param>
         /// <param name="subtypeName">
-        ///     Optionally, the name of the range's subtype or element. This is usually not needed - the subtype will be
-        ///     inferred based on <paramref name="elementClrType"/></param>
+        /// Optionally, the name of the range's subtype or element. This is usually not needed - the subtype will be
+        /// inferred based on <paramref name="elementClrType"/></param>
         /// <example>
         /// To map a range of PostgreSQL real, use the following:
         /// <code>NpgsqlTypeMappingSource.MapRange("real", typeof(float));</code>
         /// </example>
-        public virtual void MapRange([NotNull] string rangeName, [NotNull] Type elementClrType,
-            string subtypeName = null)
+        public virtual void MapRange([NotNull] string rangeName, [NotNull] Type elementClrType, string subtypeName = null)
             => WithOption(e => e.WithRangeMapping(rangeName, elementClrType, subtypeName));
 
         /// <summary>

--- a/src/EFCore.PG/Infrastructure/NpgsqlDbContextOptionsBuilder.cs
+++ b/src/EFCore.PG/Infrastructure/NpgsqlDbContextOptionsBuilder.cs
@@ -31,6 +31,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal;
+using NpgsqlTypes;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure
 {
@@ -69,22 +70,42 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure
             => WithOption(e => e.WithPostgresVersion(postgresVersion));
 
         /// <summary>
-        /// Maps a user-defined PostgreSQL range type for use with all DbContexts.
+        /// Maps a user-defined PostgreSQL range type for use.
         /// </summary>
+        /// <typeparam name="TSubtype">
+        /// The CLR type of the range's subtype (or element).
+        /// The actual mapped type will be an <see cref="NpgsqlRange{T}"/> over this type.
+        /// </typeparam>
         /// <param name="rangeName">The name of the PostgreSQL range type to be mapped.</param>
-        /// <param name="elementClrType">
-        /// The CLR type of the range's element. The actual mapped type will be an <code>NpgsqlRange{T}</code> over
-        /// this type.
-        /// </param>
         /// <param name="subtypeName">
-        /// Optionally, the name of the range's subtype or element. This is usually not needed - the subtype will be
-        /// inferred based on <paramref name="elementClrType"/></param>
+        /// Optionally, the name of the range's PostgreSQL subtype (or element).
+        /// This is usually not needed - the subtype will be inferred based on <typeparamref name="TSubtype"/>.
+        /// </param>
         /// <example>
         /// To map a range of PostgreSQL real, use the following:
-        /// <code>NpgsqlTypeMappingSource.MapRange("real", typeof(float));</code>
+        /// <code>NpgsqlTypeMappingSource.MapRange{float}("floatrange");</code>
         /// </example>
-        public virtual void MapRange([NotNull] string rangeName, [NotNull] Type elementClrType, string subtypeName = null)
-            => WithOption(e => e.WithRangeMapping(rangeName, elementClrType, subtypeName));
+        public virtual void MapRange<TSubtype>([NotNull] string rangeName, string subtypeName = null)
+            => WithOption(e => e.WithRangeMapping(rangeName, typeof(TSubtype), subtypeName));
+
+        /// <summary>
+        /// Maps a user-defined PostgreSQL range type for use.
+        /// </summary>
+        /// <param name="rangeName">The name of the PostgreSQL range type to be mapped.</param>
+        /// <param name="subtypeClrType">
+        /// The CLR type of the range's subtype (or element).
+        /// The actual mapped type will be an <see cref="NpgsqlRange{T}"/> over this type.
+        /// </param>
+        /// <param name="subtypeName">
+        /// Optionally, the name of the range's PostgreSQL subtype (or element).
+        /// This is usually not needed - the subtype will be inferred based on <paramref name="subtypeClrType"/>.
+        /// </param>
+        /// <example>
+        /// To map a range of PostgreSQL real, use the following:
+        /// <code>NpgsqlTypeMappingSource.MapRange("floatrange", typeof(float));</code>
+        /// </example>
+        public virtual void MapRange([NotNull] string rangeName, [NotNull] Type subtypeClrType, string subtypeName = null)
+            => WithOption(e => e.WithRangeMapping(rangeName, subtypeClrType, subtypeName));
 
         /// <summary>
         /// Appends NULLS FIRST to all ORDER BY clauses. This is important for the tests which were written

--- a/src/EFCore.PG/Infrastructure/NpgsqlDbContextOptionsBuilder.cs
+++ b/src/EFCore.PG/Infrastructure/NpgsqlDbContextOptionsBuilder.cs
@@ -69,6 +69,24 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure
             => WithOption(e => e.WithPostgresVersion(postgresVersion));
 
         /// <summary>
+        /// Maps a user-defined PostgreSQL range type for use with all DbContexts.
+        /// </summary>
+        /// <param name="elementClrType">
+        /// The CLR type of the range's element. The actual mapped type will be an <code>NpgsqlRange{T}</code> over
+        /// this type.
+        /// </param>
+        /// <param name="rangeName">The name of the PostgreSQL range type to be mapped.</param>
+        /// <param name="subtypeName">
+        /// Optionally, the name of the range's subtype or element. This is usually not needed - the subtype will be
+        /// inferred based on <paramref name="elementClrType"/></param>
+        /// <example>
+        /// To map a range of PostgreSQL real, use the following:
+        /// <code>NpgsqlTypeMappingSource.MapRange("real", typeof(float));</code>
+        /// </example>
+        public virtual void MapRange(Type elementClrType, string rangeName, string subtypeName=null)
+            => WithOption(e => e.WithRangeMapping(elementClrType, rangeName, subtypeName));
+
+        /// <summary>
         /// Appends NULLS FIRST to all ORDER BY clauses. This is important for the tests which were written
         /// for SQL Server. Note that to fully implement null-first ordering indexes also need to be generated
         /// accordingly, and since this isn't done this feature isn't publicly exposed.

--- a/src/EFCore.PG/Internal/NpgsqlOptions.cs
+++ b/src/EFCore.PG/Internal/NpgsqlOptions.cs
@@ -25,6 +25,7 @@
 
 using System;
 using System.Collections.Generic;
+using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
@@ -43,7 +44,18 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Internal
         public virtual bool ReverseNullOrderingEnabled { get; private set; }
 
         /// <inheritdoc />
+        [NotNull]
+        public virtual IReadOnlyList<(Type ElementClrType, string RangeName, string SubTypeName)> RangeMappings { get; private set; }
+
+        /// <inheritdoc />
+        [NotNull]
         public virtual IReadOnlyList<NpgsqlEntityFrameworkPlugin> Plugins { get; private set; }
+
+        public NpgsqlOptions()
+        {
+            RangeMappings = new (Type, string, string)[0];
+            Plugins = new NpgsqlEntityFrameworkPlugin[0];
+        }
 
         /// <inheritdoc />
         public void Initialize(IDbContextOptions options)
@@ -53,6 +65,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Internal
             PostgresVersion = npgsqlOptions.PostgresVersion;
             ReverseNullOrderingEnabled = npgsqlOptions.ReverseNullOrdering;
             Plugins = npgsqlOptions.Plugins;
+            RangeMappings = npgsqlOptions.RangeMappings;
         }
 
         /// <inheritdoc />

--- a/src/EFCore.PG/Internal/NpgsqlOptions.cs
+++ b/src/EFCore.PG/Internal/NpgsqlOptions.cs
@@ -45,7 +45,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Internal
 
         /// <inheritdoc />
         [NotNull]
-        public virtual IReadOnlyList<(Type ElementClrType, string RangeName, string SubTypeName)> RangeMappings { get; private set; }
+        public virtual IReadOnlyList<(string RangeName, Type ElementClrType, string SubTypeName)> RangeMappings { get; private set; }
 
         /// <inheritdoc />
         [NotNull]
@@ -53,7 +53,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Internal
 
         public NpgsqlOptions()
         {
-            RangeMappings = new (Type, string, string)[0];
+            RangeMappings = new (string, Type, string)[0];
             Plugins = new NpgsqlEntityFrameworkPlugin[0];
         }
 

--- a/src/EFCore.PG/Internal/NpgsqlOptions.cs
+++ b/src/EFCore.PG/Internal/NpgsqlOptions.cs
@@ -45,7 +45,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Internal
 
         /// <inheritdoc />
         [NotNull]
-        public virtual IReadOnlyList<(string RangeName, Type ElementClrType, string SubTypeName)> RangeMappings { get; private set; }
+        public virtual IReadOnlyList<RangeMappingInfo> RangeMappings { get; private set; }
 
         /// <inheritdoc />
         [NotNull]
@@ -53,7 +53,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Internal
 
         public NpgsqlOptions()
         {
-            RangeMappings = new (string, Type, string)[0];
+            RangeMappings = new RangeMappingInfo[0];
             Plugins = new NpgsqlEntityFrameworkPlugin[0];
         }
 

--- a/src/EFCore.PG/Metadata/Internal/NpgsqlAnnotationNames.cs
+++ b/src/EFCore.PG/Metadata/Internal/NpgsqlAnnotationNames.cs
@@ -35,6 +35,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.Internal
         public const string IndexMethod = Prefix + "IndexMethod";
         public const string PostgresExtensionPrefix = Prefix + "PostgresExtension:";
         public const string EnumPrefix = Prefix + "Enum:";
+        public const string RangePrefix = Prefix + "Range:";
         public const string DatabaseTemplate = Prefix + "DatabaseTemplate";
         public const string Tablespace = Prefix + "Tablespace";
         public const string StorageParameterPrefix = Prefix + "StorageParameter:";

--- a/src/EFCore.PG/Metadata/NpgsqlModelAnnotations.cs
+++ b/src/EFCore.PG/Metadata/NpgsqlModelAnnotations.cs
@@ -113,6 +113,33 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata
 
         #endregion Enum types
 
+        #region Range types
+
+        public virtual PostgresRange GetOrAddPostgresRange(
+            [CanBeNull] string schema,
+            [NotNull] string name,
+            [NotNull] string subtype,
+            string canonicalFunction = null,
+            string subtypeOpClass = null,
+            string collation = null,
+            string subtypeDiff = null)
+            => PostgresRange.GetOrAddPostgresRange((IMutableModel)Model, schema, name, subtype, canonicalFunction,
+                subtypeOpClass, collation, subtypeDiff);
+
+        public virtual PostgresRange GetOrAddPostgresRange(
+            [NotNull] string name,
+            [NotNull] string subtype)
+            => PostgresRange.GetOrAddPostgresRange((IMutableModel)Model, null, name, subtype);
+
+        public virtual IReadOnlyList<PostgresRange> PostgresRanges
+            => PostgresRange.GetPostgresRanges(Model).ToList();
+
+        #endregion Range types
+
+        #region User-defined range types
+
+        #endregion User-defined range types
+
         #region Database Template
 
         public virtual string DatabaseTemplate

--- a/src/EFCore.PG/Metadata/NpgsqlModelAnnotations.cs
+++ b/src/EFCore.PG/Metadata/NpgsqlModelAnnotations.cs
@@ -123,14 +123,22 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata
             string subtypeOpClass = null,
             string collation = null,
             string subtypeDiff = null)
-            => PostgresRange.GetOrAddPostgresRange((IMutableModel)Model, schema, name, subtype, canonicalFunction,
-                subtypeOpClass, collation, subtypeDiff);
+            => PostgresRange.GetOrAddPostgresRange(
+                (IMutableModel)Model,
+                schema,
+                name,
+                subtype,
+                canonicalFunction,
+                subtypeOpClass,
+                collation,
+                subtypeDiff);
 
         public virtual PostgresRange GetOrAddPostgresRange(
             [NotNull] string name,
             [NotNull] string subtype)
             => PostgresRange.GetOrAddPostgresRange((IMutableModel)Model, null, name, subtype);
 
+        [NotNull]
         public virtual IReadOnlyList<PostgresRange> PostgresRanges
             => PostgresRange.GetPostgresRanges(Model).ToList();
 

--- a/src/EFCore.PG/Metadata/NpgsqlModelAnnotations.cs
+++ b/src/EFCore.PG/Metadata/NpgsqlModelAnnotations.cs
@@ -144,10 +144,6 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata
 
         #endregion Range types
 
-        #region User-defined range types
-
-        #endregion User-defined range types
-
         #region Database Template
 
         public virtual string DatabaseTemplate

--- a/src/EFCore.PG/Metadata/PostgresEnum.cs
+++ b/src/EFCore.PG/Metadata/PostgresEnum.cs
@@ -52,8 +52,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata
             [NotNull] string name,
             [NotNull] string[] labels)
         {
-            var enumType = FindPostgresEnum(annotatable, schema, name);
-            if (enumType != null)
+            if (FindPostgresEnum(annotatable, schema, name) is PostgresEnum enumType)
                 return enumType;
 
             enumType = new PostgresEnum(annotatable, BuildAnnotationName(schema, name));

--- a/src/EFCore.PG/Metadata/PostgresEnum.cs
+++ b/src/EFCore.PG/Metadata/PostgresEnum.cs
@@ -52,13 +52,13 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata
             [NotNull] string name,
             [NotNull] string[] labels)
         {
-            var extension = FindPostgresEnum(annotatable, schema, name);
-            if (extension != null)
-                return extension;
+            var enumType = FindPostgresEnum(annotatable, schema, name);
+            if (enumType != null)
+                return enumType;
 
-            extension = new PostgresEnum(annotatable, BuildAnnotationName(schema, name));
-            extension.SetData(labels);
-            return extension;
+            enumType = new PostgresEnum(annotatable, BuildAnnotationName(schema, name));
+            enumType.SetData(labels);
+            return enumType;
         }
 
         public static PostgresEnum GetOrAddPostgresEnum(

--- a/src/EFCore.PG/Metadata/PostgresRange.cs
+++ b/src/EFCore.PG/Metadata/PostgresRange.cs
@@ -1,0 +1,190 @@
+﻿#region License
+// The PostgreSQL License
+//
+// Copyright (C) 2016 The Npgsql Development Team
+//
+// Permission to use, copy, modify, and distribute this software and its
+// documentation for any purpose, without fee, and without a written
+// agreement is hereby granted, provided that the above copyright notice
+// and this paragraph and the following two paragraphs appear in all copies.
+//
+// IN NO EVENT SHALL THE NPGSQL DEVELOPMENT TEAM BE LIABLE TO ANY PARTY
+// FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES,
+// INCLUDING LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS
+// DOCUMENTATION, EVEN IF THE NPGSQL DEVELOPMENT TEAM HAS BEEN ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//
+// THE NPGSQL DEVELOPMENT TEAM SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS
+// ON AN "AS IS" BASIS, AND THE NPGSQL DEVELOPMENT TEAM HAS NO OBLIGATIONS
+// TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Storage;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.Internal;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Utilities;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata
+{
+    public class PostgresRange
+    {
+        readonly IAnnotatable _annotatable;
+        readonly string _annotationName;
+
+        internal PostgresRange(IAnnotatable annotatable, string annotationName)
+        {
+            _annotatable = annotatable;
+            _annotationName = annotationName;
+        }
+
+        public static PostgresRange GetOrAddPostgresRange(
+            [NotNull] IMutableAnnotatable annotatable,
+            [CanBeNull] string schema,
+            [NotNull] string name,
+            [NotNull] string subtype,
+            string canonicalFunction = null,
+            string subtypeOpClass = null,
+            string collation = null,
+            string subtypeDiff = null)
+        {
+            var rangeType = FindPostgresRange(annotatable, schema, name);
+            if (rangeType != null)
+                return rangeType;
+
+            rangeType = new PostgresRange(annotatable, BuildAnnotationName(schema, name));
+            rangeType.SetData(subtype, canonicalFunction, subtypeOpClass, collation, subtypeDiff);
+            return rangeType;
+        }
+
+        public static PostgresRange FindPostgresRange(
+            [NotNull] IAnnotatable annotatable,
+            [CanBeNull] string schema,
+            [NotNull] string name)
+        {
+            Check.NotNull(annotatable, nameof(annotatable));
+            Check.NotEmpty(name, nameof(name));
+
+            var annotationName = BuildAnnotationName(schema, name);
+
+            return annotatable[annotationName] == null ? null : new PostgresRange(annotatable, annotationName);
+        }
+
+        static string BuildAnnotationName(string schema, string name)
+            => NpgsqlAnnotationNames.RangePrefix + (schema == null ? name : schema + '.' + name);
+
+        public static IEnumerable<PostgresRange> GetPostgresRanges([NotNull] IAnnotatable annotatable)
+        {
+            Check.NotNull(annotatable, nameof(annotatable));
+
+            return annotatable.GetAnnotations()
+                .Where(a => a.Name.StartsWith(NpgsqlAnnotationNames.RangePrefix, StringComparison.Ordinal))
+                .Select(a => new PostgresRange(annotatable, a.Name));
+        }
+
+        public Annotatable Annotatable => (Annotatable)_annotatable;
+
+        public string Schema => GetData().Schema;
+
+        public string Name => GetData().Name;
+
+        public string Subtype
+        {
+            get => GetData().Subtype;
+            set
+            {
+                var x = GetData();
+                var (_, _, _, canonicalFunction, subtypeOpClass, collation, subtypeDiff) = GetData();
+                SetData(value, canonicalFunction, subtypeOpClass, collation, subtypeDiff);
+            }
+        }
+
+        public string CanonicalFunction
+        {
+            get => GetData().CanonicalFunction;
+            set
+            {
+                var x = GetData();
+                var (_, _, subtype, _, subtypeOpClass, collation, subtypeDiff) = GetData();
+                SetData(subtype, value, subtypeOpClass, collation, subtypeDiff);
+            }
+        }
+
+        public string SubtypeOpClass
+        {
+            get => GetData().SubtypeOpClass;
+            set
+            {
+                var x = GetData();
+                var (_, _, subtype, canonicalFunction, _, collation, subtypeDiff) = GetData();
+                SetData(subtype, canonicalFunction, value, collation, subtypeDiff);
+            }
+        }
+
+        public string Collation
+        {
+            get => GetData().Collation;
+            set
+            {
+                var x = GetData();
+                var (_, _, subtype, canonicalFunction, subtypeOpClass, _, subtypeDiff) = GetData();
+                SetData(subtype, canonicalFunction, subtypeOpClass, value, subtypeDiff);
+            }
+        }
+
+        public string SubtypeDiff
+        {
+            get => GetData().SubtypeDiff;
+            set
+            {
+                var x = GetData();
+                var (_, _, subtype, canonicalFunction, subtypeOpClass, collation, _) = GetData();
+                SetData(subtype, canonicalFunction, subtypeOpClass, collation, value);
+            }
+        }
+
+        (string Schema, string Name, string Subtype, string CanonicalFunction, string SubtypeOpClass, string Collation,
+            string SubtypeDiff) GetData()
+        {
+            return !(Annotatable[_annotationName] is string annotationValue)
+                ? (null, null, null, null, null, null, null)
+                : Deserialize(_annotationName, annotationValue);
+        }
+
+        void SetData(string subtype, string canonicalFunction, string subtypeOpClass, string collation, string subtypeDiff)
+            => Annotatable[_annotationName] = $"{subtype},{canonicalFunction},{subtypeOpClass},{collation},{subtypeDiff}";
+
+        static (string Schema, string Name, string Subtype, string CanonicalFunction, string SubtypeOpClass, string collation, string SubtypeDiff)
+            Deserialize([NotNull] string annotationName, [NotNull] string annotationValue)
+        {
+            Check.NotEmpty(annotationValue, nameof(annotationValue));
+
+            var elements = annotationValue.Split(',').ToArray();
+            if (elements.Length != 5)
+                throw new ArgumentException("Cannot parse range annotation value: " + annotationValue);
+            for (var i = 0; i < 5; i++)
+                if (elements[i] == "")
+                    elements[i] = null;
+
+            // Yes, this doesn't support dots in the schema/range name, let somebody complain first.
+            var schemaAndName = annotationName.Substring(NpgsqlAnnotationNames.RangePrefix.Length).Split('.');
+            switch (schemaAndName.Length)
+            {
+            case 1:
+                return (null, schemaAndName[0], elements[0], elements[1], elements[2], elements[3], elements[4]);
+            case 2:
+                return (schemaAndName[0], schemaAndName[1], elements[0], elements[1], elements[2], elements[3], elements[4]);
+            default:
+                throw new ArgumentException("Cannot parse enum name from annotation: " + annotationName);
+            }
+        }
+    }
+}

--- a/src/EFCore.PG/Migrations/Internal/NpgsqlMigrationsAnnotationProvider.cs
+++ b/src/EFCore.PG/Migrations/Internal/NpgsqlMigrationsAnnotationProvider.cs
@@ -75,6 +75,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations.Internal
         public override IEnumerable<IAnnotation> For(IModel model)
             => model.GetAnnotations().Where(a =>
                 a.Name.StartsWith(NpgsqlAnnotationNames.PostgresExtensionPrefix, StringComparison.Ordinal) ||
-                a.Name.StartsWith(NpgsqlAnnotationNames.EnumPrefix, StringComparison.Ordinal));
+                a.Name.StartsWith(NpgsqlAnnotationNames.EnumPrefix, StringComparison.Ordinal) ||
+                a.Name.StartsWith(NpgsqlAnnotationNames.RangePrefix, StringComparison.Ordinal));
     }
 }

--- a/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
@@ -725,11 +725,12 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations
                 GenerateDropEnum(enumTypeToDrop, builder);
             }
 
-            foreach (var enumTypeToAlter in from newEnum in PostgresEnum.GetPostgresEnums(operation)
-                join oldEnum in PostgresEnum.GetPostgresEnums(operation.OldDatabase) on newEnum.Name equals oldEnum.Name
-                select new { newEnum.Name, OldLabels = oldEnum.Labels, newLabels = newEnum.Labels })
+            // TODO: Some forms of enum alterations are actually supported...
+            if (PostgresEnum.GetPostgresEnums(operation).FirstOrDefault(nr =>
+                PostgresEnum.GetPostgresEnums(operation.OldDatabase).Any(or => or.Name == nr.Name)
+            ) is PostgresEnum enumTypeToAlter)
             {
-                // TODO: Some forms of enum alterations are actually supported... At least log...
+                throw new NotSupportedException($"Altering enum type ${enumTypeToAlter} isn't supported.");
             }
         }
 

--- a/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
@@ -28,6 +28,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
@@ -670,27 +671,11 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations
             Check.NotNull(operation, nameof(operation));
             Check.NotNull(builder, nameof(builder));
 
+            GenerateEnumStatements(operation, model, builder);
+            GenerateRangeStatements(operation, model, builder);
+
             foreach (var extension in PostgresExtension.GetPostgresExtensions(operation))
                 GenerateCreateExtension(extension, model, builder);
-
-            foreach (var enumTypeToCreate in PostgresEnum.GetPostgresEnums(operation)
-                .Where(ne => PostgresEnum.GetPostgresEnums(operation.OldDatabase).All(oe => oe.Name != ne.Name)))
-            {
-                GenerateCreateEnum(enumTypeToCreate, model, builder);
-            }
-
-            foreach (var enumTypeToDrop in PostgresEnum.GetPostgresEnums(operation.OldDatabase)
-                .Where(oe => PostgresEnum.GetPostgresEnums(operation).All(ne => ne.Name != oe.Name)))
-            {
-                GenerateDropEnum(enumTypeToDrop, builder);
-            }
-
-            foreach (var enumTypeToAlter in from newEnum in PostgresEnum.GetPostgresEnums(operation)
-                join oldEnum in PostgresEnum.GetPostgresEnums(operation.OldDatabase) on newEnum.Name equals oldEnum.Name
-                select new { newEnum.Name, OldLabels = oldEnum.Labels, newLabels = newEnum.Labels })
-            {
-                // TODO: Some forms of enum alterations are actually supported... At least log...
-            }
 
             builder.EndCommand();
         }
@@ -719,6 +704,33 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations
             }
 
             builder.AppendLine(';');
+        }
+
+        #region Enum management
+
+        protected virtual void GenerateEnumStatements(
+                AlterDatabaseOperation operation,
+                IModel model,
+                MigrationCommandListBuilder builder)
+        {
+            foreach (var enumTypeToCreate in PostgresEnum.GetPostgresEnums(operation)
+                .Where(ne => PostgresEnum.GetPostgresEnums(operation.OldDatabase).All(oe => oe.Name != ne.Name)))
+            {
+                GenerateCreateEnum(enumTypeToCreate, model, builder);
+            }
+
+            foreach (var enumTypeToDrop in PostgresEnum.GetPostgresEnums(operation.OldDatabase)
+                .Where(oe => PostgresEnum.GetPostgresEnums(operation).All(ne => ne.Name != oe.Name)))
+            {
+                GenerateDropEnum(enumTypeToDrop, builder);
+            }
+
+            foreach (var enumTypeToAlter in from newEnum in PostgresEnum.GetPostgresEnums(operation)
+                join oldEnum in PostgresEnum.GetPostgresEnums(operation.OldDatabase) on newEnum.Name equals oldEnum.Name
+                select new { newEnum.Name, OldLabels = oldEnum.Labels, newLabels = newEnum.Labels })
+            {
+                // TODO: Some forms of enum alterations are actually supported... At least log...
+            }
         }
 
         protected virtual void GenerateCreateEnum(
@@ -756,6 +768,81 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations
                 .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(@enum.Name, @enum.Schema))
                 .AppendLine(";");
         }
+
+        #endregion Enum management
+
+        #region Range management
+
+        protected virtual void GenerateRangeStatements(
+                AlterDatabaseOperation operation,
+                IModel model,
+                MigrationCommandListBuilder builder)
+        {
+            foreach (var rangeTypeToCreate in PostgresRange.GetPostgresRanges(operation)
+                .Where(ne => PostgresRange.GetPostgresRanges(operation.OldDatabase).All(oe => oe.Name != ne.Name)))
+            {
+                GenerateCreateRange(rangeTypeToCreate, model, builder);
+            }
+
+            foreach (var rangeTypeToDrop in PostgresRange.GetPostgresRanges(operation.OldDatabase)
+                .Where(oe => PostgresRange.GetPostgresRanges(operation).All(ne => ne.Name != oe.Name)))
+            {
+                GenerateDropRange(rangeTypeToDrop, builder);
+            }
+
+            foreach (var rangeTypeToAlter in from newRange in PostgresRange.GetPostgresRanges(operation)
+                join oldRange in PostgresRange.GetPostgresRanges(operation.OldDatabase) on newRange.Name equals oldRange.Name
+                select oldRange)
+            {
+                throw new NotSupportedException($"Altering range type ${rangeTypeToAlter} isn't supported.");
+            }
+        }
+
+        protected virtual void GenerateCreateRange(
+            PostgresRange rangeType,
+            IModel model,
+            MigrationCommandListBuilder builder)
+        {
+            // Schemas are normally created (or rather ensured) by the model differ, which scans all tables, sequences
+            // and other database objects. However, it isn't aware of ranges, so we always ensure schema on range creation.
+            if (rangeType.Schema != null)
+                Generate(new EnsureSchemaOperation { Name=rangeType.Schema }, model, builder);
+
+            builder
+                .Append("CREATE TYPE ")
+                .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(rangeType.Name, rangeType.Schema))
+                .AppendLine($" AS RANGE (")
+                .IncrementIndent();
+
+            var def = new List<string> { $"SUBTYPE = {rangeType.Subtype}" };
+            if (rangeType.CanonicalFunction != null)
+                def.Add($"CANONICAL = {rangeType.CanonicalFunction}");
+            if (rangeType.SubtypeOpClass != null)
+                def.Add($"SUBTYPE_OPCLASS = {rangeType.SubtypeOpClass}");
+            if (rangeType.CanonicalFunction != null)
+                def.Add($"COLLATION = {rangeType.Collation}");
+            if (rangeType.SubtypeDiff != null)
+                def.Add($"SUBTYPE_DIFF = {rangeType.SubtypeDiff}");
+
+            for (var i = 0; i < def.Count; i++)
+                builder
+                    .Append(def[i] + (i == def.Count - 1 ? null : ","))
+                    .AppendLine();
+
+            builder
+                .DecrementIndent()
+                .AppendLine(");");
+        }
+
+        protected virtual void GenerateDropRange(PostgresRange rangeType, MigrationCommandListBuilder builder)
+        {
+            builder
+                .Append("DROP TYPE ")
+                .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(rangeType.Name, rangeType.Schema))
+                .AppendLine(";");
+        }
+
+        #endregion Range management
 
         protected override void Generate(DropIndexOperation operation, [CanBeNull] IModel model, MigrationCommandListBuilder builder)
         {

--- a/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
@@ -709,9 +709,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations
         #region Enum management
 
         protected virtual void GenerateEnumStatements(
-                AlterDatabaseOperation operation,
-                IModel model,
-                MigrationCommandListBuilder builder)
+                [NotNull] AlterDatabaseOperation operation,
+                [NotNull] IModel model,
+                [NotNull] MigrationCommandListBuilder builder)
         {
             foreach (var enumTypeToCreate in PostgresEnum.GetPostgresEnums(operation)
                 .Where(ne => PostgresEnum.GetPostgresEnums(operation.OldDatabase).All(oe => oe.Name != ne.Name)))
@@ -734,9 +734,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations
         }
 
         protected virtual void GenerateCreateEnum(
-            PostgresEnum enumType,
-            IModel model,
-            MigrationCommandListBuilder builder)
+            [NotNull] PostgresEnum enumType,
+            [NotNull] IModel model,
+            [NotNull] MigrationCommandListBuilder builder)
         {
             // Schemas are normally created (or rather ensured) by the model differ, which scans all tables, sequences
             // and other database objects. However, it isn't aware of enums, so we always ensure schema on enum creation.
@@ -761,11 +761,11 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations
             builder.AppendLine(");");
         }
 
-        protected virtual void GenerateDropEnum(PostgresEnum @enum, MigrationCommandListBuilder builder)
+        protected virtual void GenerateDropEnum([NotNull] PostgresEnum enumType, [NotNull] MigrationCommandListBuilder builder)
         {
             builder
                 .Append("DROP TYPE ")
-                .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(@enum.Name, @enum.Schema))
+                .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(enumType.Name, enumType.Schema))
                 .AppendLine(";");
         }
 
@@ -774,9 +774,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations
         #region Range management
 
         protected virtual void GenerateRangeStatements(
-                AlterDatabaseOperation operation,
-                IModel model,
-                MigrationCommandListBuilder builder)
+                [NotNull] AlterDatabaseOperation operation,
+                [NotNull] IModel model,
+                [NotNull] MigrationCommandListBuilder builder)
         {
             foreach (var rangeTypeToCreate in PostgresRange.GetPostgresRanges(operation)
                 .Where(ne => PostgresRange.GetPostgresRanges(operation.OldDatabase).All(oe => oe.Name != ne.Name)))
@@ -790,18 +790,18 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations
                 GenerateDropRange(rangeTypeToDrop, builder);
             }
 
-            foreach (var rangeTypeToAlter in from newRange in PostgresRange.GetPostgresRanges(operation)
-                join oldRange in PostgresRange.GetPostgresRanges(operation.OldDatabase) on newRange.Name equals oldRange.Name
-                select oldRange)
+            if (PostgresRange.GetPostgresRanges(operation).FirstOrDefault(nr =>
+                    PostgresRange.GetPostgresRanges(operation.OldDatabase).Any(or => or.Name == nr.Name)
+                ) is PostgresRange rangeTypeToAlter)
             {
                 throw new NotSupportedException($"Altering range type ${rangeTypeToAlter} isn't supported.");
             }
         }
 
         protected virtual void GenerateCreateRange(
-            PostgresRange rangeType,
-            IModel model,
-            MigrationCommandListBuilder builder)
+            [NotNull] PostgresRange rangeType,
+            [NotNull] IModel model,
+            [NotNull] MigrationCommandListBuilder builder)
         {
             // Schemas are normally created (or rather ensured) by the model differ, which scans all tables, sequences
             // and other database objects. However, it isn't aware of ranges, so we always ensure schema on range creation.
@@ -834,7 +834,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations
                 .AppendLine(");");
         }
 
-        protected virtual void GenerateDropRange(PostgresRange rangeType, MigrationCommandListBuilder builder)
+        protected virtual void GenerateDropRange([NotNull] PostgresRange rangeType, [NotNull] MigrationCommandListBuilder builder)
         {
             builder
                 .Append("DROP TYPE ")

--- a/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlRangeTypeMapping.cs
+++ b/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlRangeTypeMapping.cs
@@ -24,6 +24,7 @@
 #endregion
 
 using System;
+using System.Diagnostics;
 using System.Text;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -32,16 +33,15 @@ using NpgsqlTypes;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
 {
-    public class NpgsqlRangeTypeMapping<T> : NpgsqlTypeMapping
+    public class NpgsqlRangeTypeMapping : NpgsqlTypeMapping
     {
         public RelationalTypeMapping SubtypeMapping { get; }
 
         public NpgsqlRangeTypeMapping(
             [NotNull] string storeType,
             [NotNull] Type clrType,
-            RelationalTypeMapping subtypeMapping,
-            NpgsqlDbType subtypeNpgsqlDbType)
-            : base(storeType, clrType, NpgsqlDbType.Range | subtypeNpgsqlDbType)
+            RelationalTypeMapping subtypeMapping)
+            : base(storeType, clrType, GenerateNpgsqlDbType(subtypeMapping))
         {
             SubtypeMapping = subtypeMapping;
         }
@@ -50,20 +50,32 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
             : base(parameters, npgsqlDbType) { }
 
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new NpgsqlRangeTypeMapping<T>(Parameters.WithStoreTypeAndSize(storeType, size), NpgsqlDbType);
+            => new NpgsqlRangeTypeMapping(Parameters.WithStoreTypeAndSize(storeType, size), NpgsqlDbType);
 
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new NpgsqlRangeTypeMapping<T>(Parameters.WithComposedConverter(converter), NpgsqlDbType);
+            => new NpgsqlRangeTypeMapping(Parameters.WithComposedConverter(converter), NpgsqlDbType);
 
         protected override string GenerateNonNullSqlLiteral(object value)
         {
-            var range = (NpgsqlRange<T>)value;
             var sb = new StringBuilder();
             sb.Append('\'');
-            sb.Append(range.ToString());
+            sb.Append(value);
             sb.Append("'::");
             sb.Append(StoreType);
             return sb.ToString();
+        }
+
+        static NpgsqlDbType GenerateNpgsqlDbType(RelationalTypeMapping subtypeMapping)
+        {
+            if (subtypeMapping is NpgsqlTypeMapping npgsqlTypeMapping)
+                return NpgsqlDbType.Range | npgsqlTypeMapping.NpgsqlDbType;
+
+            // We're using a built-in, non-Npgsql mapping such as IntTypeMapping.
+            // Infer the NpgsqlDbType from the DbType (somewhat hacky but why not).
+            Debug.Assert(subtypeMapping.DbType.HasValue);
+            var p = new NpgsqlParameter();
+            p.DbType = subtypeMapping.DbType.Value;
+            return NpgsqlDbType.Range | p.NpgsqlDbType;
         }
     }
 }

--- a/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlRangeTypeMapping.cs
+++ b/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlRangeTypeMapping.cs
@@ -40,18 +40,18 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
         public NpgsqlRangeTypeMapping(
             [NotNull] string storeType,
             [NotNull] Type clrType,
-            RelationalTypeMapping subtypeMapping)
+            [NotNull] RelationalTypeMapping subtypeMapping)
             : base(storeType, clrType, GenerateNpgsqlDbType(subtypeMapping))
-        {
-            SubtypeMapping = subtypeMapping;
-        }
+        => SubtypeMapping = subtypeMapping;
 
         protected NpgsqlRangeTypeMapping(RelationalTypeMappingParameters parameters, NpgsqlDbType npgsqlDbType)
             : base(parameters, npgsqlDbType) { }
 
+        [NotNull]
         public override RelationalTypeMapping Clone(string storeType, int? size)
             => new NpgsqlRangeTypeMapping(Parameters.WithStoreTypeAndSize(storeType, size), NpgsqlDbType);
 
+        [NotNull]
         public override CoreTypeMapping Clone(ValueConverter converter)
             => new NpgsqlRangeTypeMapping(Parameters.WithComposedConverter(converter), NpgsqlDbType);
 
@@ -65,7 +65,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
             return sb.ToString();
         }
 
-        static NpgsqlDbType GenerateNpgsqlDbType(RelationalTypeMapping subtypeMapping)
+        static NpgsqlDbType GenerateNpgsqlDbType([NotNull] RelationalTypeMapping subtypeMapping)
         {
             if (subtypeMapping is NpgsqlTypeMapping npgsqlTypeMapping)
                 return NpgsqlDbType.Range | npgsqlTypeMapping.NpgsqlDbType;

--- a/src/EFCore.PG/Storage/Internal/NpgsqlDatabaseCreator.cs
+++ b/src/EFCore.PG/Storage/Internal/NpgsqlDatabaseCreator.cs
@@ -317,10 +317,13 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
             var commands = Dependencies.MigrationsSqlGenerator.Generate(operations, Dependencies.Model);
 
             // If a PostgreSQL extension or enum was added, we want Npgsql to reload all types at the ADO.NET level.
-            var reloadTypes = operations.Any(o => o is AlterDatabaseOperation &&
-                (PostgresExtension.GetPostgresExtensions(o).Any() ||
-                 PostgresEnum.GetPostgresEnums(o).Any() ||
-                 PostgresRange.GetPostgresRanges(o).Any()));
+            var reloadTypes = operations.Any(o =>
+                o is AlterDatabaseOperation && (
+                    PostgresExtension.GetPostgresExtensions(o).Any() ||
+                    PostgresEnum.GetPostgresEnums(o).Any() ||
+                    PostgresRange.GetPostgresRanges(o).Any()
+                )
+            );
 
             try
             {

--- a/src/EFCore.PG/Storage/Internal/NpgsqlDatabaseCreator.cs
+++ b/src/EFCore.PG/Storage/Internal/NpgsqlDatabaseCreator.cs
@@ -319,7 +319,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
             // If a PostgreSQL extension or enum was added, we want Npgsql to reload all types at the ADO.NET level.
             var reloadTypes = operations.Any(o => o is AlterDatabaseOperation &&
                 (PostgresExtension.GetPostgresExtensions(o).Any() ||
-                 PostgresEnum.GetPostgresEnums(o).Any()));
+                 PostgresEnum.GetPostgresEnums(o).Any() ||
+                 PostgresRange.GetPostgresRanges(o).Any()));
 
             try
             {

--- a/src/EFCore.PG/Storage/Internal/NpgsqlDatabaseCreator.cs
+++ b/src/EFCore.PG/Storage/Internal/NpgsqlDatabaseCreator.cs
@@ -316,7 +316,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
             var operations = Dependencies.ModelDiffer.GetDifferences(null, Dependencies.Model);
             var commands = Dependencies.MigrationsSqlGenerator.Generate(operations, Dependencies.Model);
 
-            // If a PostgreSQL extension or enum was added, we want Npgsql to reload all types at the ADO.NET level.
+            // If a PostgreSQL extension, enum or range was added, we want Npgsql to reload all types at the ADO.NET level.
             var reloadTypes = operations.Any(o =>
                 o is AlterDatabaseOperation && (
                     PostgresExtension.GetPostgresExtensions(o).Any() ||

--- a/src/EFCore.PG/Storage/Internal/NpgsqlTypeMappingSource.cs
+++ b/src/EFCore.PG/Storage/Internal/NpgsqlTypeMappingSource.cs
@@ -111,12 +111,12 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
         readonly NpgsqlTsRankingNormalizationTypeMapping _rankingNormalization = new NpgsqlTsRankingNormalizationTypeMapping();
 
         // Built-in ranges
-        readonly NpgsqlRangeTypeMapping<int>      _int4range;
-        readonly NpgsqlRangeTypeMapping<long>     _int8range;
-        readonly NpgsqlRangeTypeMapping<decimal>  _numrange;
-        readonly NpgsqlRangeTypeMapping<DateTime> _tsrange;
-        readonly NpgsqlRangeTypeMapping<DateTime> _tstzrange;
-        readonly NpgsqlRangeTypeMapping<DateTime> _daterange;
+        readonly NpgsqlRangeTypeMapping        _int4range;
+        readonly NpgsqlRangeTypeMapping        _int8range;
+        readonly NpgsqlRangeTypeMapping        _numrange;
+        readonly NpgsqlRangeTypeMapping        _tsrange;
+        readonly NpgsqlRangeTypeMapping        _tstzrange;
+        readonly NpgsqlRangeTypeMapping        _daterange;
 
         // Other types
         readonly NpgsqlBoolTypeMapping         _bool               = new NpgsqlBoolTypeMapping();
@@ -134,12 +134,12 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
             : base(dependencies, relationalDependencies)
         {
             // Initialize some mappings which depend on other mappings
-            _int4range = new NpgsqlRangeTypeMapping<int>("int4range", typeof(NpgsqlRange<int>), _int4, NpgsqlDbType.Integer);
-            _int8range = new NpgsqlRangeTypeMapping<long>("int8range", typeof(NpgsqlRange<long>), _int8, NpgsqlDbType.Bigint);
-            _numrange  = new NpgsqlRangeTypeMapping<decimal>("numrange",  typeof(NpgsqlRange<decimal>), _numeric, NpgsqlDbType.Numeric);
-            _tsrange   = new NpgsqlRangeTypeMapping<DateTime>("tsrange", typeof(NpgsqlRange<DateTime>), _timestamp, NpgsqlDbType.Range | NpgsqlDbType.Timestamp);
-            _tstzrange = new NpgsqlRangeTypeMapping<DateTime>("tstzrange", typeof(NpgsqlRange<DateTime>), _timestamptz, NpgsqlDbType.Range | NpgsqlDbType.TimestampTz);
-            _daterange = new NpgsqlRangeTypeMapping<DateTime>("daterange", typeof(NpgsqlRange<DateTime>), _timestamptz, NpgsqlDbType.Range | NpgsqlDbType.Date);
+            _int4range = new NpgsqlRangeTypeMapping("int4range", typeof(NpgsqlRange<int>), _int4);
+            _int8range = new NpgsqlRangeTypeMapping("int8range", typeof(NpgsqlRange<long>), _int8);
+            _numrange  = new NpgsqlRangeTypeMapping("numrange",  typeof(NpgsqlRange<decimal>), _numeric);
+            _tsrange   = new NpgsqlRangeTypeMapping("tsrange",   typeof(NpgsqlRange<DateTime>), _timestamp);
+            _tstzrange = new NpgsqlRangeTypeMapping("tstzrange", typeof(NpgsqlRange<DateTime>), _timestamptz);
+            _daterange = new NpgsqlRangeTypeMapping("daterange", typeof(NpgsqlRange<DateTime>), _timestamptz);
 
             // Note that PostgreSQL has aliases to some built-in type name aliases (e.g. int4 for integer),
             // these are mapped as well.
@@ -263,9 +263,32 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
             StoreTypeMappings = new ConcurrentDictionary<string, RelationalTypeMapping[]>(storeTypeMappings, StringComparer.OrdinalIgnoreCase);
             ClrTypeMappings = new ConcurrentDictionary<Type, RelationalTypeMapping>(clrTypeMappings);
 
-            if (npgsqlOptions?.Plugins != null)
+            if (npgsqlOptions != null)
+            {
+                foreach (var (elementClrType, rangeName, subtypeName) in npgsqlOptions.RangeMappings)
+                {
+                    RelationalTypeMapping subtypeMapping;
+                    if (subtypeName == null)
+                    {
+                        if (!ClrTypeMappings.TryGetValue(elementClrType, out subtypeMapping))
+                            throw new Exception($"Could not map range {rangeName}, no mapping was found for element type {elementClrType}");
+                    }
+                    else
+                    {
+                        if (StoreTypeMappings.TryGetValue(subtypeName, out var subtypeMappings))
+                            throw new Exception($"Could not map range {rangeName}, no mapping was found for subtype {subtypeName}");
+                        subtypeMapping = subtypeMappings[0];
+                    }
+
+                    var rangeClrType = typeof(NpgsqlRange<>).MakeGenericType(elementClrType);
+                    var rangeMapping = new NpgsqlRangeTypeMapping(rangeName, rangeClrType, subtypeMapping);
+                    StoreTypeMappings[rangeName] = new RelationalTypeMapping[] { rangeMapping };
+                    ClrTypeMappings[rangeClrType] = rangeMapping;
+                }
+
                 foreach (var plugin in npgsqlOptions.Plugins)
                     plugin.AddMappings(this);
+            }
 
             LoadUserDefinedTypeMappings();
         }

--- a/src/EFCore.PG/Storage/Internal/NpgsqlTypeMappingSource.cs
+++ b/src/EFCore.PG/Storage/Internal/NpgsqlTypeMappingSource.cs
@@ -268,17 +268,17 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
             if (npgsqlOptions == null)
                 return;
 
-            foreach (var (rangeName, elementClrType, subtypeName) in npgsqlOptions.RangeMappings)
+            foreach (var (rangeName, subtypeClrType, subtypeName) in npgsqlOptions.RangeMappings)
             {
                 var subtypeMapping = subtypeName == null
-                    ? ClrTypeMappings.TryGetValue(elementClrType, out var mapping)
+                    ? ClrTypeMappings.TryGetValue(subtypeClrType, out var mapping)
                         ? mapping
-                        : throw new Exception($"Could not map range {rangeName}, no mapping was found for element type {elementClrType}")
+                        : throw new Exception($"Could not map range {rangeName}, no mapping was found for subtype CLR type {subtypeClrType}")
                     : StoreTypeMappings.TryGetValue(subtypeName, out var mappings)
                         ? mappings[0]
                         : throw new Exception($"Could not map range {rangeName}, no mapping was found for subtype {subtypeName}");
 
-                var rangeClrType = typeof(NpgsqlRange<>).MakeGenericType(elementClrType);
+                var rangeClrType = typeof(NpgsqlRange<>).MakeGenericType(subtypeClrType);
                 var rangeMapping = new NpgsqlRangeTypeMapping(rangeName, rangeClrType, subtypeMapping);
                 StoreTypeMappings[rangeName] = new RelationalTypeMapping[] { rangeMapping };
                 ClrTypeMappings[rangeClrType] = rangeMapping;

--- a/test/EFCore.PG.FunctionalTests/Query/RangeQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/RangeQueryNpgsqlTest.cs
@@ -570,7 +570,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
                     new DbContextOptionsBuilder()
                         .UseNpgsql(_testStore.ConnectionString, b =>
                         {
-                            b.MapRange(typeof(float), "floatrange");
+                            b.MapRange("floatrange", typeof(float));
                             b.ApplyConfiguration();
                         })
                         .UseInternalServiceProvider(
@@ -651,24 +651,10 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             }
         }
 
-        /// <summary>
-        /// Represents an entity suitable for testing range operators.
-        /// </summary>
         public class RangeTestEntity
         {
-            /// <summary>
-            /// The primary key.
-            /// </summary>
             public int Id { get; set; }
-
-            /// <summary>
-            /// The range of integers.
-            /// </summary>
             public NpgsqlRange<int> Range { get; set; }
-
-            /// <summary>
-            /// The range of integers.
-            /// </summary>
             public NpgsqlRange<float> FloatRange { get; set; }
         }
 

--- a/test/EFCore.PG.FunctionalTests/Query/RangeQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/RangeQueryNpgsqlTest.cs
@@ -490,6 +490,17 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             }
         }
 
+        [Fact]
+        public void UserDefined()
+        {
+            using (RangeContext context = Fixture.CreateContext())
+            {
+                var e = context.RangeTestEntities.Single(x => x.FloatRange.UpperBound > 5);
+                Assert.Equal(e.FloatRange.LowerBound, 0);
+                Assert.Equal(e.FloatRange.UpperBound, 10);
+            }
+        }
+
         #endregion Tests
 
         #region TheoryData
@@ -533,12 +544,12 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             /// <summary>
             /// The <see cref="NpgsqlTestStore"/> used for testing.
             /// </summary>
-            private readonly NpgsqlTestStore _testStore;
+            readonly NpgsqlTestStore _testStore;
 
             /// <summary>
             /// The <see cref="DbContextOptions"/> used for testing.
             /// </summary>
-            private readonly DbContextOptions _options;
+            readonly DbContextOptions _options;
 
             /// <summary>
             /// The logger factory used for testing.
@@ -557,7 +568,11 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
 
                 _options =
                     new DbContextOptionsBuilder()
-                        .UseNpgsql(_testStore.ConnectionString, b => b.ApplyConfiguration())
+                        .UseNpgsql(_testStore.ConnectionString, b =>
+                        {
+                            b.MapRange(typeof(float), "floatrange");
+                            b.ApplyConfiguration();
+                        })
                         .UseInternalServiceProvider(
                             new ServiceCollection()
                                 .AddEntityFrameworkNpgsql()
@@ -575,6 +590,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
                             Id = 1,
                             // (0, 10)
                             Range = new NpgsqlRange<int>(0, false, false, 10, false, false),
+                            FloatRange = new NpgsqlRange<float>(0, false, false, 10, false, false)
                         },
                         new RangeTestEntity
                         {
@@ -649,6 +665,11 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             /// The range of integers.
             /// </summary>
             public NpgsqlRange<int> Range { get; set; }
+
+            /// <summary>
+            /// The range of integers.
+            /// </summary>
+            public NpgsqlRange<float> FloatRange { get; set; }
         }
 
         /// <summary>
@@ -670,7 +691,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             public RangeContext(DbContextOptions options) : base(options) { }
 
             /// <inheritdoc />
-            protected override void OnModelCreating(ModelBuilder builder) { }
+            protected override void OnModelCreating(ModelBuilder builder)
+                => builder.ForNpgsqlHasRange("floatrange", "real");
         }
 
         #endregion


### PR DESCRIPTION
* Added an Npgsql options extension to allow users to map user-defined   ranges.
* Added modeling for range types, to allow creation of user-defined range types in migrations.
* Simplified and improved range mapping.

Closes #329