### PR TITLE
Cleanup style and document public API surfaces

### DIFF
--- a/src/EFCore.PG.NTS/NetTopologySuiteMethodCallTranslator.cs
+++ b/src/EFCore.PG.NTS/NetTopologySuiteMethodCallTranslator.cs
@@ -1,13 +1,19 @@
 ﻿using System.Linq.Expressions;
 using GeoAPI.Geometries;
+using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 using NetTopologySuite.Geometries;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite
 {
+    /// <summary>
+    /// Translates methods operating on types implementing the <see cref="IGeometry"/> interface.
+    /// </summary>
     public class NetTopologySuiteMethodCallTranslator : IMethodCallTranslator
     {
+        /// <inheritdoc />
+        [CanBeNull]
         public virtual Expression Translate(MethodCallExpression e)
         {
             if (!typeof(IGeometry).IsAssignableFrom(e.Method.DeclaringType))

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlDateAddTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlDateAddTranslator.cs
@@ -92,7 +92,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Inte
             // Note that a make_interval() function also exists, but accepts only int (for all fields except for
             // seconds), so we don't use it.
 
-            Expression interval = null;
+            Expression interval;
 
             var instance = methodCallExpression.Object;
             var amountToAdd = methodCallExpression.Arguments[0];
@@ -124,11 +124,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Inte
             // We could use the provider-specific NpgsqlTimeSpan but it's not currently supported and is somewhat
             // ugly, so we just generate the expression ourselves with CustomBinaryExpression
 
-            return new CustomBinaryExpression(
-                methodCallExpression.Object,
-                interval,
-                "+",
-                methodCallExpression.Type);
+            return new CustomBinaryExpression(instance, interval, "+", methodCallExpression.Type);
         }
     }
 }

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlFullTextSearchMethodTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlFullTextSearchMethodTranslator.cs
@@ -48,7 +48,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Inte
         static readonly MethodInfo TsVectorParse =
             typeof(NpgsqlTsVector).GetMethod(nameof(NpgsqlTsVector.Parse), BindingFlags.Public | BindingFlags.Static);
 
-        static readonly IReadOnlyDictionary<string, string> SQLNameByMethodName = new Dictionary<string, string>
+        static readonly IReadOnlyDictionary<string, string> SqlNameByMethodName = new Dictionary<string, string>
         {
             [nameof(NpgsqlFullTextSearchDbFunctionsExtensions.ArrayToTsVector)] = "array_to_tsvector",
             [nameof(NpgsqlFullTextSearchDbFunctionsExtensions.ToTsVector)] = "to_tsvector",
@@ -64,8 +64,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Inte
             if (e.Method == TsQueryParse || e.Method == TsVectorParse)
                 return new ExplicitCastExpression(e.Arguments[0], e.Method.ReturnType);
 
-            if (e.Method.DeclaringType == typeof(NpgsqlFullTextSearchDbFunctionsExtensions)
-                && SQLNameByMethodName.TryGetValue(e.Method.Name, out var sqlFunctionName))
+            if (e.Method.DeclaringType == typeof(NpgsqlFullTextSearchDbFunctionsExtensions) &&
+                SqlNameByMethodName.TryGetValue(e.Method.Name, out var sqlFunctionName))
                 return new SqlFunctionExpression(sqlFunctionName, e.Method.ReturnType, e.Arguments.Skip(1));
 
             if (e.Method.DeclaringType == typeof(NpgsqlFullTextSearchLinqExtensions))
@@ -120,15 +120,14 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Inte
                 return new SqlFunctionExpression("querytree", e.Method.ReturnType, e.Arguments);
 
             case nameof(NpgsqlFullTextSearchLinqExtensions.GetResultHeadline):
-                const string tsheadlineFunctionName = "ts_headline";
                 switch (e.Arguments.Count)
                 {
                 case 2:
-                    return new SqlFunctionExpression(tsheadlineFunctionName, e.Method.ReturnType, e.Arguments.Reverse());
+                    return new SqlFunctionExpression("ts_headline", e.Method.ReturnType, e.Arguments.Reverse());
 
                 case 3:
                     return new SqlFunctionExpression(
-                        tsheadlineFunctionName,
+                        "ts_headline",
                         e.Method.ReturnType,
                         new[]
                         {
@@ -139,7 +138,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Inte
 
                 case 4:
                     return new SqlFunctionExpression(
-                        tsheadlineFunctionName,
+                        "ts_headline",
                         e.Method.ReturnType,
                         new[]
                         {
@@ -150,9 +149,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Inte
                         });
 
                 default:
-                    throw new ArgumentException(
-                        $"Invalid method overload for {tsheadlineFunctionName}",
-                        nameof(e));
+                    throw new ArgumentException("Invalid method overload for ts_headline", nameof(e));
                 }
 
             case nameof(NpgsqlFullTextSearchLinqExtensions.Rewrite):

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlFullTextSearchMethodTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlFullTextSearchMethodTranslator.cs
@@ -1,4 +1,5 @@
 ﻿#region License
+
 // The PostgreSQL License
 //
 // Copyright (C) 2016 The Npgsql Development Team
@@ -19,6 +20,7 @@
 // AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS
 // ON AN "AS IS" BASIS, AND THE NPGSQL DEVELOPMENT TEAM HAS NO OBLIGATIONS
 // TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+
 #endregion
 
 using System;
@@ -26,6 +28,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
@@ -34,47 +37,45 @@ using NpgsqlTypes;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Internal
 {
+    /// <summary>
+    /// Provides translations for PostgreSQL full-text search methods.
+    /// </summary>
     public class NpgsqlFullTextSearchMethodTranslator : IMethodCallTranslator
     {
-        static readonly MethodInfo _tsQueryParse = typeof(NpgsqlTsQuery).GetMethod(
-            nameof(NpgsqlTsQuery.Parse),
-            BindingFlags.Public | BindingFlags.Static);
+        static readonly MethodInfo TsQueryParse =
+            typeof(NpgsqlTsQuery).GetMethod(nameof(NpgsqlTsQuery.Parse), BindingFlags.Public | BindingFlags.Static);
 
-        static readonly MethodInfo _tsVectorParse = typeof(NpgsqlTsVector).GetMethod(
-            nameof(NpgsqlTsVector.Parse),
-            BindingFlags.Public | BindingFlags.Static);
+        static readonly MethodInfo TsVectorParse =
+            typeof(NpgsqlTsVector).GetMethod(nameof(NpgsqlTsVector.Parse), BindingFlags.Public | BindingFlags.Static);
 
-        static readonly IReadOnlyDictionary<string, string> _sqlNameByMethodName =
-            new Dictionary<string, string>
-            {
-                [nameof(NpgsqlFullTextSearchDbFunctionsExtensions.ArrayToTsVector)] = "array_to_tsvector",
-                [nameof(NpgsqlFullTextSearchDbFunctionsExtensions.ToTsVector)] = "to_tsvector",
-                [nameof(NpgsqlFullTextSearchDbFunctionsExtensions.PlainToTsQuery)] = "plainto_tsquery",
-                [nameof(NpgsqlFullTextSearchDbFunctionsExtensions.PhraseToTsQuery)] = "phraseto_tsquery",
-                [nameof(NpgsqlFullTextSearchDbFunctionsExtensions.ToTsQuery)] = "to_tsquery"
-            };
-
-        public Expression Translate(MethodCallExpression methodCallExpression)
+        static readonly IReadOnlyDictionary<string, string> SQLNameByMethodName = new Dictionary<string, string>
         {
-            if (methodCallExpression.Method == _tsQueryParse || methodCallExpression.Method == _tsVectorParse)
-                return new ExplicitCastExpression(
-                    methodCallExpression.Arguments[0],
-                    methodCallExpression.Method.ReturnType);
+            [nameof(NpgsqlFullTextSearchDbFunctionsExtensions.ArrayToTsVector)] = "array_to_tsvector",
+            [nameof(NpgsqlFullTextSearchDbFunctionsExtensions.ToTsVector)] = "to_tsvector",
+            [nameof(NpgsqlFullTextSearchDbFunctionsExtensions.PlainToTsQuery)] = "plainto_tsquery",
+            [nameof(NpgsqlFullTextSearchDbFunctionsExtensions.PhraseToTsQuery)] = "phraseto_tsquery",
+            [nameof(NpgsqlFullTextSearchDbFunctionsExtensions.ToTsQuery)] = "to_tsquery"
+        };
 
-            if (methodCallExpression.Method.DeclaringType == typeof(NpgsqlFullTextSearchDbFunctionsExtensions)
-                && _sqlNameByMethodName.TryGetValue(methodCallExpression.Method.Name, out var sqlFunctionName))
-                return new SqlFunctionExpression(
-                    sqlFunctionName,
-                    methodCallExpression.Method.ReturnType,
-                    methodCallExpression.Arguments.Skip(1));
+        /// <inheritdoc />
+        [CanBeNull]
+        public Expression Translate(MethodCallExpression e)
+        {
+            if (e.Method == TsQueryParse || e.Method == TsVectorParse)
+                return new ExplicitCastExpression(e.Arguments[0], e.Method.ReturnType);
 
-            if (methodCallExpression.Method.DeclaringType == typeof(NpgsqlFullTextSearchLinqExtensions))
-                return TryTranslateOperator(methodCallExpression) ?? TryTranslateFunction(methodCallExpression);
+            if (e.Method.DeclaringType == typeof(NpgsqlFullTextSearchDbFunctionsExtensions)
+                && SQLNameByMethodName.TryGetValue(e.Method.Name, out var sqlFunctionName))
+                return new SqlFunctionExpression(sqlFunctionName, e.Method.ReturnType, e.Arguments.Skip(1));
+
+            if (e.Method.DeclaringType == typeof(NpgsqlFullTextSearchLinqExtensions))
+                return TryTranslateOperator(e) ?? TryTranslateFunction(e);
 
             return null;
         }
 
-        static Expression TryTranslateOperator(MethodCallExpression e)
+        [CanBeNull]
+        static Expression TryTranslateOperator([NotNull] MethodCallExpression e)
         {
             switch (e.Method.Name)
             {
@@ -107,75 +108,61 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Inte
             }
         }
 
-        static Expression TryTranslateFunction(MethodCallExpression methodCallExpression)
+        [CanBeNull]
+        static Expression TryTranslateFunction([NotNull] MethodCallExpression e)
         {
-            switch (methodCallExpression.Method.Name)
+            switch (e.Method.Name)
             {
             case nameof(NpgsqlFullTextSearchLinqExtensions.GetNodeCount):
-                return new SqlFunctionExpression(
-                    "numnode",
-                    methodCallExpression.Method.ReturnType,
-                    methodCallExpression.Arguments);
+                return new SqlFunctionExpression("numnode", e.Method.ReturnType, e.Arguments);
 
             case nameof(NpgsqlFullTextSearchLinqExtensions.GetQueryTree):
-                return new SqlFunctionExpression(
-                    "querytree",
-                    methodCallExpression.Method.ReturnType,
-                    methodCallExpression.Arguments);
+                return new SqlFunctionExpression("querytree", e.Method.ReturnType, e.Arguments);
 
             case nameof(NpgsqlFullTextSearchLinqExtensions.GetResultHeadline):
-                var tsheadlineFunctionName = "ts_headline";
-                switch (methodCallExpression.Arguments.Count)
+                const string tsheadlineFunctionName = "ts_headline";
+                switch (e.Arguments.Count)
                 {
                 case 2:
-                    return new SqlFunctionExpression(
-                        tsheadlineFunctionName,
-                        methodCallExpression.Method.ReturnType,
-                        methodCallExpression.Arguments.Reverse());
+                    return new SqlFunctionExpression(tsheadlineFunctionName, e.Method.ReturnType, e.Arguments.Reverse());
 
                 case 3:
                     return new SqlFunctionExpression(
                         tsheadlineFunctionName,
-                        methodCallExpression.Method.ReturnType,
+                        e.Method.ReturnType,
                         new[]
                         {
-                            methodCallExpression.Arguments[1],
-                            methodCallExpression.Arguments[0],
-                            methodCallExpression.Arguments[2]
+                            e.Arguments[1],
+                            e.Arguments[0],
+                            e.Arguments[2]
                         });
 
                 case 4:
                     return new SqlFunctionExpression(
                         tsheadlineFunctionName,
-                        methodCallExpression.Method.ReturnType,
+                        e.Method.ReturnType,
                         new[]
                         {
-                            methodCallExpression.Arguments[1],
-                            methodCallExpression.Arguments[2],
-                            methodCallExpression.Arguments[0],
-                            methodCallExpression.Arguments[3]
+                            e.Arguments[1],
+                            e.Arguments[2],
+                            e.Arguments[0],
+                            e.Arguments[3]
                         });
 
                 default:
                     throw new ArgumentException(
                         $"Invalid method overload for {tsheadlineFunctionName}",
-                        nameof(methodCallExpression));
+                        nameof(e));
                 }
 
             case nameof(NpgsqlFullTextSearchLinqExtensions.Rewrite):
-                return new SqlFunctionExpression(
-                    "ts_rewrite",
-                    methodCallExpression.Method.ReturnType,
-                    methodCallExpression.Arguments);
+                return new SqlFunctionExpression("ts_rewrite", e.Method.ReturnType, e.Arguments);
 
             case nameof(NpgsqlFullTextSearchLinqExtensions.ToPhrase):
-                return new SqlFunctionExpression(
-                    "tsquery_phrase",
-                    methodCallExpression.Method.ReturnType,
-                    methodCallExpression.Arguments);
+                return new SqlFunctionExpression("tsquery_phrase", e.Method.ReturnType, e.Arguments);
 
             case nameof(NpgsqlFullTextSearchLinqExtensions.SetWeight):
-                var arguments = methodCallExpression.Arguments.ToArray();
+                var arguments = e.Arguments.ToArray();
 
                 if (arguments[1].Type == typeof(NpgsqlTsVector.Lexeme.Weight))
                 {
@@ -188,57 +175,42 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Inte
                     arguments[1] = Expression.Constant(weightExpression.Value.ToString()[0]);
                 }
 
-                return new SqlFunctionExpression(
-                    "setweight",
-                    methodCallExpression.Method.ReturnType,
-                    arguments);
+                return new SqlFunctionExpression("setweight", e.Method.ReturnType, arguments);
 
             case nameof(NpgsqlFullTextSearchLinqExtensions.Delete):
-                return new SqlFunctionExpression(
-                    "ts_delete",
-                    methodCallExpression.Method.ReturnType,
-                    methodCallExpression.Arguments);
+                return new SqlFunctionExpression("ts_delete", e.Method.ReturnType, e.Arguments);
 
             case nameof(NpgsqlFullTextSearchLinqExtensions.Filter):
                 return new SqlFunctionExpression(
                     "ts_filter",
-                    methodCallExpression.Method.ReturnType,
+                    e.Method.ReturnType,
                     new[]
                     {
-                        methodCallExpression.Arguments[0],
-                        new ExplicitStoreTypeCastExpression(methodCallExpression.Arguments[1], typeof(char[]), "\"char\"[]")
+                        e.Arguments[0],
+                        new ExplicitStoreTypeCastExpression(e.Arguments[1], typeof(char[]), "\"char\"[]")
                     });
 
             case nameof(NpgsqlFullTextSearchLinqExtensions.GetLength):
-                return new SqlFunctionExpression(
-                    "length",
-                    methodCallExpression.Method.ReturnType,
-                    methodCallExpression.Arguments);
+                return new SqlFunctionExpression("length", e.Method.ReturnType, e.Arguments);
 
             case nameof(NpgsqlFullTextSearchLinqExtensions.ToStripped):
-                return new SqlFunctionExpression(
-                    "strip",
-                    methodCallExpression.Method.ReturnType,
-                    methodCallExpression.Arguments);
+                return new SqlFunctionExpression("strip", e.Method.ReturnType, e.Arguments);
 
             case nameof(NpgsqlFullTextSearchLinqExtensions.Rank):
             case nameof(NpgsqlFullTextSearchLinqExtensions.RankCoverDensity):
-                var rankFunctionName = methodCallExpression.Method.Name == nameof(NpgsqlFullTextSearchLinqExtensions.Rank)
+                var rankFunctionName = e.Method.Name == nameof(NpgsqlFullTextSearchLinqExtensions.Rank)
                     ? "ts_rank"
                     : "ts_rank_cd";
 
-                switch (methodCallExpression.Arguments.Count)
+                switch (e.Arguments.Count)
                 {
                 case 2:
-                    return new SqlFunctionExpression(
-                        rankFunctionName,
-                        methodCallExpression.Method.ReturnType,
-                        methodCallExpression.Arguments);
+                    return new SqlFunctionExpression(rankFunctionName, e.Method.ReturnType, e.Arguments);
 
                 case 3:
-                    var firstArgument = methodCallExpression.Arguments[0];
-                    var secondArgument = methodCallExpression.Arguments[1];
-                    if (methodCallExpression.Arguments[1].Type == typeof(float[]))
+                    var firstArgument = e.Arguments[0];
+                    var secondArgument = e.Arguments[1];
+                    if (e.Arguments[1].Type == typeof(float[]))
                     {
                         var temp = firstArgument;
                         firstArgument = secondArgument;
@@ -247,30 +219,30 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Inte
 
                     return new SqlFunctionExpression(
                         rankFunctionName,
-                        methodCallExpression.Method.ReturnType,
+                        e.Method.ReturnType,
                         new[]
                         {
                             firstArgument,
                             secondArgument,
-                            methodCallExpression.Arguments[2]
+                            e.Arguments[2]
                         });
 
                 case 4:
                     return new SqlFunctionExpression(
                         rankFunctionName,
-                        methodCallExpression.Method.ReturnType,
+                        e.Method.ReturnType,
                         new[]
                         {
-                            methodCallExpression.Arguments[1],
-                            methodCallExpression.Arguments[0],
-                            methodCallExpression.Arguments[2],
-                            methodCallExpression.Arguments[3]
+                            e.Arguments[1],
+                            e.Arguments[0],
+                            e.Arguments[2],
+                            e.Arguments[3]
                         });
 
                 default:
                     throw new ArgumentException(
                         $"Invalid method overload for {rankFunctionName}",
-                        nameof(methodCallExpression));
+                        nameof(e));
                 }
 
             default:

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlFullTextSearchMethodTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlFullTextSearchMethodTranslator.cs
@@ -64,8 +64,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Inte
             if (e.Method == TsQueryParse || e.Method == TsVectorParse)
                 return new ExplicitCastExpression(e.Arguments[0], e.Method.ReturnType);
 
-            if (e.Method.DeclaringType == typeof(NpgsqlFullTextSearchDbFunctionsExtensions) &&
-                SqlNameByMethodName.TryGetValue(e.Method.Name, out var sqlFunctionName))
+            if (e.Method.DeclaringType == typeof(NpgsqlFullTextSearchDbFunctionsExtensions)
+                && SqlNameByMethodName.TryGetValue(e.Method.Name, out var sqlFunctionName))
                 return new SqlFunctionExpression(sqlFunctionName, e.Method.ReturnType, e.Arguments.Skip(1));
 
             if (e.Method.DeclaringType == typeof(NpgsqlFullTextSearchLinqExtensions))

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlStringEndsWithTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlStringEndsWithTranslator.cs
@@ -42,23 +42,17 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Inte
         /// <inheritdoc />
         [CanBeNull]
         public virtual Expression Translate(MethodCallExpression e)
-        {
-            var instance = e.Object;
-
-            if (instance == null || !ReferenceEquals(e.Method, MethodInfo))
-                return null;
-
-            return
-                Expression.Equal(
+            => e.Object != null && ReferenceEquals(e.Method, MethodInfo)
+                ? Expression.Equal(
                     new SqlFunctionExpression(
                         "RIGHT",
-                        instance.Type,
+                        e.Object.Type,
                         new[]
                         {
-                            instance,
+                            e.Object,
                             new SqlFunctionExpression("LENGTH", typeof(int), new[] { e.Arguments[0] })
                         }),
-                    e.Arguments[0]);
-        }
+                    e.Arguments[0])
+                : null;
     }
 }

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlStringEndsWithTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlStringEndsWithTranslator.cs
@@ -1,4 +1,5 @@
 ﻿#region License
+
 // The PostgreSQL License
 //
 // Copyright (C) 2016 The Npgsql Development Team
@@ -19,35 +20,45 @@
 // AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS
 // ON AN "AS IS" BASIS, AND THE NPGSQL DEVELOPMENT TEAM HAS NO OBLIGATIONS
 // TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+
 #endregion
 
 using System.Linq.Expressions;
 using System.Reflection;
+using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Internal
 {
+    /// <summary>
+    /// Translates <see cref="M:string.EndsWith(string)"/> to 'RIGHT(text, int) = text'.
+    /// </summary>
     public class NpgsqlStringEndsWithTranslator : IMethodCallTranslator
     {
-        static readonly MethodInfo _methodInfo
-            = typeof(string).GetRuntimeMethod(nameof(string.EndsWith), new[] { typeof(string) });
+        static readonly MethodInfo MethodInfo =
+            typeof(string).GetRuntimeMethod(nameof(string.EndsWith), new[] { typeof(string) });
 
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
-            => ReferenceEquals(methodCallExpression.Method, _methodInfo)
-                ? Expression.Equal(
+        /// <inheritdoc />
+        [CanBeNull]
+        public virtual Expression Translate(MethodCallExpression e)
+        {
+            var instance = e.Object;
+
+            if (instance == null || !ReferenceEquals(e.Method, MethodInfo))
+                return null;
+
+            return
+                Expression.Equal(
                     new SqlFunctionExpression(
                         "RIGHT",
-                        // ReSharper disable once PossibleNullReferenceException
-                        methodCallExpression.Object.Type,
+                        instance.Type,
                         new[]
                         {
-                            methodCallExpression.Object,
-                            new SqlFunctionExpression("LENGTH", typeof(int), new[] { methodCallExpression.Arguments[0] })
-                        }
-                    ),
-                    methodCallExpression.Arguments[0]
-                )
-                : null;
+                            instance,
+                            new SqlFunctionExpression("LENGTH", typeof(int), new[] { e.Arguments[0] })
+                        }),
+                    e.Arguments[0]);
+        }
     }
 }

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlStringIndexOfTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlStringIndexOfTranslator.cs
@@ -1,4 +1,5 @@
 ﻿#region License
+
 // The PostgreSQL License
 //
 // Copyright (C) 2016 The Npgsql Development Team
@@ -19,6 +20,7 @@
 // AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS
 // ON AN "AS IS" BASIS, AND THE NPGSQL DEVELOPMENT TEAM HAS NO OBLIGATIONS
 // TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+
 #endregion
 
 using System.Linq;
@@ -30,27 +32,27 @@ using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Internal
 {
+    /// <summary>
+    /// Translates <see cref="M:string.IndexOf(string)"/> and <see cref="M:string.IndexOf(char)"/>
+    /// to 'STRPOS(text, text) - 1'.
+    /// </summary>
     public class NpgsqlStringIndexOfTranslator : IMethodCallTranslator
     {
-        static readonly MethodInfo _indexOfString
-            = typeof(string).GetRuntimeMethod(nameof(string.IndexOf), new[] { typeof(string) });
+        static readonly MethodInfo IndexOfString =
+            typeof(string).GetRuntimeMethod(nameof(string.IndexOf), new[] { typeof(string) });
 
-        static readonly MethodInfo _indexOfChar
-            = typeof(string).GetRuntimeMethod(nameof(string.IndexOf), new[] { typeof(char) });
+        static readonly MethodInfo IndexOfChar =
+            typeof(string).GetRuntimeMethod(nameof(string.IndexOf), new[] { typeof(char) });
 
-        public virtual Expression Translate([NotNull] MethodCallExpression methodCallExpression)
+        /// <inheritdoc />
+        [CanBeNull]
+        public virtual Expression Translate(MethodCallExpression e)
         {
-            if (!_indexOfString.Equals(methodCallExpression.Method) &&
-                !_indexOfChar.Equals(methodCallExpression.Method))
-            {
+            if (!IndexOfString.Equals(e.Method) && !IndexOfChar.Equals(e.Method))
                 return null;
-            }
 
             return Expression.Subtract(
-                new SqlFunctionExpression(
-                    "STRPOS",
-                    methodCallExpression.Type,
-                    new[] { methodCallExpression.Object }.Concat(methodCallExpression.Arguments)),
+                new SqlFunctionExpression("STRPOS", e.Type, new[] { e.Object }.Concat(e.Arguments)),
                 Expression.Constant(1)
             );
         }

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlStringIsNullOrWhiteSpaceTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlStringIsNullOrWhiteSpaceTranslator.cs
@@ -1,4 +1,5 @@
 ﻿#region License
+
 // The PostgreSQL License
 //
 // Copyright (C) 2016 The Npgsql Development Team
@@ -19,33 +20,35 @@
 // AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS
 // ON AN "AS IS" BASIS, AND THE NPGSQL DEVELOPMENT TEAM HAS NO OBLIGATIONS
 // TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+
 #endregion
 
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Text.RegularExpressions;
+using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Query.Expressions.Internal;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Internal
 {
+    /// <summary>
+    /// Translates <see cref="M:string.IsNullOrWhiteSpace(string)"/>.
+    /// </summary>
     public class NpgsqlStringIsNullOrWhiteSpaceTranslator : IMethodCallTranslator
     {
-        static readonly MethodInfo _methodInfo
-            = typeof(string).GetRuntimeMethod(nameof(string.IsNullOrWhiteSpace), new[] { typeof(string) });
+        static readonly MethodInfo MethodInfo =
+            typeof(string).GetRuntimeMethod(nameof(string.IsNullOrWhiteSpace), new[] { typeof(string) });
 
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
-            => _methodInfo.Equals(methodCallExpression.Method)
+        /// <inheritdoc />
+        [CanBeNull]
+        public virtual Expression Translate(MethodCallExpression e)
+            => MethodInfo.Equals(e.Method)
                 ? Expression.MakeBinary(
                     ExpressionType.OrElse,
-                    new IsNullExpression(methodCallExpression.Arguments[0]),
-                    new RegexMatchExpression(
-                        methodCallExpression.Arguments[0],
-                        Expression.Constant(@"^\s*$"),
-                        RegexOptions.Singleline
-                    )
-                )
+                    new IsNullExpression(e.Arguments[0]),
+                    new RegexMatchExpression(e.Arguments[0], Expression.Constant(@"^\s*$"), RegexOptions.Singleline))
                 : null;
     }
 }

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlStringLengthTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlStringLengthTranslator.cs
@@ -1,4 +1,5 @@
 ﻿#region License
+
 // The PostgreSQL License
 //
 // Copyright (C) 2016 The Npgsql Development Team
@@ -19,6 +20,7 @@
 // AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS
 // ON AN "AS IS" BASIS, AND THE NPGSQL DEVELOPMENT TEAM HAS NO OBLIGATIONS
 // TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+
 #endregion
 
 using System.Linq.Expressions;
@@ -28,13 +30,18 @@ using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Internal
 {
+    /// <summary>
+    /// Translates <see cref="M:string.Length"/> to 'LENGTH(text)'.
+    /// </summary>
     public class NpgsqlStringLengthTranslator : IMemberTranslator
     {
-        public virtual Expression Translate([NotNull] MemberExpression memberExpression)
-            => (memberExpression.Expression != null)
-               && (memberExpression.Expression.Type == typeof(string))
-               && (memberExpression.Member.Name == nameof(string.Length))
-                ? new SqlFunctionExpression("LENGTH", memberExpression.Type, new[] { memberExpression.Expression })
+        /// <inheritdoc />
+        [CanBeNull]
+        public virtual Expression Translate(MemberExpression e)
+            => e.Expression != null &&
+               e.Expression.Type == typeof(string) &&
+               e.Member.Name == nameof(string.Length)
+                ? new SqlFunctionExpression("LENGTH", e.Type, new[] { e.Expression })
                 : null;
     }
 }

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlStringReplaceTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlStringReplaceTranslator.cs
@@ -1,4 +1,5 @@
 ﻿#region License
+
 // The PostgreSQL License
 //
 // Copyright (C) 2016 The Npgsql Development Team
@@ -19,6 +20,7 @@
 // AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS
 // ON AN "AS IS" BASIS, AND THE NPGSQL DEVELOPMENT TEAM HAS NO OBLIGATIONS
 // TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+
 #endregion
 
 using System.Linq;
@@ -30,17 +32,19 @@ using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Internal
 {
+    /// <summary>
+    /// Translates <see cref="M:string.Replace(string, string)"/> to 'Replace(text, text)'.
+    /// </summary>
     public class NpgsqlStringReplaceTranslator : IMethodCallTranslator
     {
-        static readonly MethodInfo _methodInfo
-            = typeof(string).GetRuntimeMethod(nameof(string.Replace), new[] { typeof(string), typeof(string) });
+        static readonly MethodInfo MethodInfo =
+            typeof(string).GetRuntimeMethod(nameof(string.Replace), new[] { typeof(string), typeof(string) });
 
-        public virtual Expression Translate([NotNull] MethodCallExpression methodCallExpression)
-            => _methodInfo.Equals(methodCallExpression.Method)
-                ? new SqlFunctionExpression(
-                    "REPLACE",
-                    methodCallExpression.Type,
-                    new[] { methodCallExpression.Object }.Concat(methodCallExpression.Arguments))
+        /// <inheritdoc />
+        [CanBeNull]
+        public virtual Expression Translate(MethodCallExpression e)
+            => MethodInfo.Equals(e.Method)
+                ? new SqlFunctionExpression("REPLACE", e.Type, new[] { e.Object }.Concat(e.Arguments))
                 : null;
     }
 }

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlStringSubstringTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlStringSubstringTranslator.cs
@@ -1,4 +1,5 @@
 ﻿#region License
+
 // The PostgreSQL License
 //
 // Copyright (C) 2016 The Npgsql Development Team
@@ -19,6 +20,7 @@
 // AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS
 // ON AN "AS IS" BASIS, AND THE NPGSQL DEVELOPMENT TEAM HAS NO OBLIGATIONS
 // TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+
 #endregion
 
 using System.Linq;
@@ -30,33 +32,31 @@ using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Internal
 {
+    /// <summary>
+    /// Translates <see cref="M:string.Substring(int, int)"/>.
+    /// </summary>
     public class NpgsqlStringSubstringTranslator : IMethodCallTranslator
     {
-        static readonly MethodInfo _methodInfo = typeof(string).GetTypeInfo()
-            .GetDeclaredMethods(nameof(string.Substring))
-            .Single(m => m.GetParameters().Length == 2);
+        static readonly MethodInfo MethodInfo =
+            typeof(string).GetTypeInfo()
+                          .GetDeclaredMethods(nameof(string.Substring))
+                          .Single(m => m.GetParameters().Length == 2);
 
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
+        /// <inheritdoc />
         [CanBeNull]
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
-            => methodCallExpression.Method.Equals(_methodInfo)
+        public virtual Expression Translate(MethodCallExpression e)
+            => e.Method.Equals(MethodInfo)
                 ? new SqlFunctionExpression(
                     "SUBSTRING",
-                    methodCallExpression.Type,
+                    e.Type,
                     new[]
                     {
-                        methodCallExpression.Object,
+                        e.Object,
                         // Accommodate for SQL Server assumption of 1-based string indexes
-                        methodCallExpression.Arguments[0].NodeType == ExpressionType.Constant
-                            ? (Expression)Expression.Constant(
-                                (int)((ConstantExpression)methodCallExpression.Arguments[0]).Value + 1)
-                            : Expression.Add(
-                                methodCallExpression.Arguments[0],
-                                Expression.Constant(1)),
-                        methodCallExpression.Arguments[1]
+                        e.Arguments[0].NodeType == ExpressionType.Constant
+                            ? (Expression)Expression.Constant((int)((ConstantExpression)e.Arguments[0]).Value + 1)
+                            : Expression.Add(e.Arguments[0], Expression.Constant(1)),
+                        e.Arguments[1]
                     })
                 : null;
     }

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlStringTrimTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlStringTrimTranslator.cs
@@ -4,26 +4,32 @@
 using System;
 using System.Linq.Expressions;
 using System.Reflection;
+using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Internal
 {
+    /// <summary>
+    /// Translates <see cref="M:string.Trim()"/>.
+    /// </summary>
     public class NpgsqlStringTrimTranslator : IMethodCallTranslator
     {
-        static readonly MethodInfo _trim
-            = typeof(string).GetRuntimeMethod(nameof(string.Trim), new Type[0]);
+        static readonly MethodInfo Trim =
+            typeof(string).GetRuntimeMethod(nameof(string.Trim), Type.EmptyTypes);
 
-        static readonly MethodInfo _trimWithChars
-            = typeof(string).GetRuntimeMethod(nameof(string.Trim), new[] { typeof(char[]) });
+        static readonly MethodInfo TrimWithChars =
+            typeof(string).GetRuntimeMethod(nameof(string.Trim), new[] { typeof(char[]) });
 
         // The following exists as an optimization in netcoreapp20
-        static readonly MethodInfo _trimWithSingleChar
-            = typeof(string).GetRuntimeMethod(nameof(string.Trim), new[] { typeof(char) });
+        static readonly MethodInfo TrimWithSingleChar =
+            typeof(string).GetRuntimeMethod(nameof(string.Trim), new[] { typeof(char) });
 
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        /// <inheritdoc />
+        [CanBeNull]
+        public virtual Expression Translate(MethodCallExpression e)
         {
-            if (methodCallExpression.Method.Equals(_trim))
+            if (e.Method.Equals(Trim))
             {
                 // Note that PostgreSQL TRIM() does spaces only, not all whitespace, so we use a regex
                 return new SqlFunctionExpression(
@@ -31,16 +37,15 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Inte
                     typeof(string),
                     new[]
                     {
-                        methodCallExpression.Object,
+                        e.Object,
                         Expression.Constant(@"^\s*(.*?)\s*$"),
                         Expression.Constant(@"\1")
                     });
             }
 
-            if (methodCallExpression.Method.Equals(_trimWithChars))
+            if (e.Method.Equals(TrimWithChars))
             {
-                var constantTrimChars = methodCallExpression.Arguments[0] as ConstantExpression;
-                if (constantTrimChars == null)
+                if (!(e.Arguments[0] is ConstantExpression constantTrimChars))
                     return null;
 
                 return new SqlFunctionExpression(
@@ -48,28 +53,25 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Inte
                     typeof(string),
                     new[]
                     {
-                        methodCallExpression.Object,
+                        e.Object,
                         Expression.Constant(new string((char[])constantTrimChars.Value))
                     });
             }
 
-            if (methodCallExpression.Method.Equals(_trimWithSingleChar))
-            {
-                var constantTrimChar = methodCallExpression.Arguments[0] as ConstantExpression;
-                if (constantTrimChar == null)
-                    return null;
+            if (!e.Method.Equals(TrimWithSingleChar))
+                return null;
 
-                return new SqlFunctionExpression(
-                    "BTRIM",
-                    typeof(string),
-                    new[]
-                    {
-                        methodCallExpression.Object,
-                        Expression.Constant(new string((char)constantTrimChar.Value, 1))
-                    });
-            }
+            if (!(e.Arguments[0] is ConstantExpression constantTrimChar))
+                return null;
 
-            return null;
+            return new SqlFunctionExpression(
+                "BTRIM",
+                typeof(string),
+                new[]
+                {
+                    e.Object,
+                    Expression.Constant(new string((char)constantTrimChar.Value, 1))
+                });
         }
     }
 }


### PR DESCRIPTION
Just going through and doing some housekeeping in `Npgsql.EntityFrameworkCore.PostgreSQL.Query`.

This includes some refactoring (mostly Rider auto-fixes + some pattern matching), so the refactors should be pure, but if something looks questionable, I'm happy to revert.

/cc @roji @YohDeadfall @rwasef1830 

