### PR TITLE
Update range mapping for schema-qualified and quoted ranges

### DIFF
--- a/src/EFCore.PG.NodaTime/Storage/Internal/NpgsqlNodaTimeTypeMappingSourcePlugin.cs
+++ b/src/EFCore.PG.NodaTime/Storage/Internal/NpgsqlNodaTimeTypeMappingSourcePlugin.cs
@@ -41,14 +41,14 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
         /// <summary>
         /// Constructs an instance of the <see cref="NpgsqlNodaTimeTypeMappingSourcePlugin"/> class.
         /// </summary>
-        public NpgsqlNodaTimeTypeMappingSourcePlugin()
+        public NpgsqlNodaTimeTypeMappingSourcePlugin([NotNull] ISqlGenerationHelper sqlGenerationHelper)
         {
-            _timestampLocalDateTimeRange = new NpgsqlRangeTypeMapping("tsrange", typeof(NpgsqlRange<LocalDateTime>), _timestampLocalDateTime);
-            _timestampInstantRange = new NpgsqlRangeTypeMapping("tsrange", typeof(NpgsqlRange<Instant>), _timestampInstant);
-            _timestamptzInstantRange = new NpgsqlRangeTypeMapping("tstzrange", typeof(NpgsqlRange<Instant>), _timestamptzInstant);
-            _timestamptzZonedDateTimeRange = new NpgsqlRangeTypeMapping("tstzrange", typeof(NpgsqlRange<ZonedDateTime>), _timestamptzZonedDateTime);
-            _timestamptzOffsetDateTimeRange = new NpgsqlRangeTypeMapping("tstzrange", typeof(NpgsqlRange<OffsetDateTime>), _timestamptzOffsetDateTime);
-            _dateRange = new NpgsqlRangeTypeMapping("daterange", typeof(NpgsqlRange<LocalDate>), _date);
+            _timestampLocalDateTimeRange = new NpgsqlRangeTypeMapping("tsrange", typeof(NpgsqlRange<LocalDateTime>), _timestampLocalDateTime, sqlGenerationHelper);
+            _timestampInstantRange = new NpgsqlRangeTypeMapping("tsrange", typeof(NpgsqlRange<Instant>), _timestampInstant, sqlGenerationHelper);
+            _timestamptzInstantRange = new NpgsqlRangeTypeMapping("tstzrange", typeof(NpgsqlRange<Instant>), _timestamptzInstant, sqlGenerationHelper);
+            _timestamptzZonedDateTimeRange = new NpgsqlRangeTypeMapping("tstzrange", typeof(NpgsqlRange<ZonedDateTime>), _timestamptzZonedDateTime, sqlGenerationHelper);
+            _timestamptzOffsetDateTimeRange = new NpgsqlRangeTypeMapping("tstzrange", typeof(NpgsqlRange<OffsetDateTime>), _timestamptzOffsetDateTime, sqlGenerationHelper);
+            _dateRange = new NpgsqlRangeTypeMapping("daterange", typeof(NpgsqlRange<LocalDate>), _date, sqlGenerationHelper);
 
             var storeTypeMappings = new Dictionary<string, RelationalTypeMapping[]>(StringComparer.OrdinalIgnoreCase)
             {

--- a/src/EFCore.PG/Design/Internal/NpgsqlAnnotationCodeGenerator.cs
+++ b/src/EFCore.PG/Design/Internal/NpgsqlAnnotationCodeGenerator.cs
@@ -90,6 +90,17 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Design.Internal
             {
                 var rangeTypeDef = new PostgresRange(model, annotation.Name);
 
+                if (rangeTypeDef.CanonicalFunction == null &&
+                    rangeTypeDef.SubtypeOpClass == null &&
+                    rangeTypeDef.Collation == null &&
+                    rangeTypeDef.SubtypeDiff == null)
+                {
+                    return new MethodCallCodeFragment(nameof(NpgsqlModelBuilderExtensions.ForNpgsqlHasRange),
+                        rangeTypeDef.Schema == "public" ? null : rangeTypeDef.Schema,
+                        rangeTypeDef.Name,
+                        rangeTypeDef.Subtype);
+                }
+
                 return new MethodCallCodeFragment(nameof(NpgsqlModelBuilderExtensions.ForNpgsqlHasRange),
                     rangeTypeDef.Schema == "public" ? null : rangeTypeDef.Schema,
                     rangeTypeDef.Name,

--- a/src/EFCore.PG/Design/Internal/NpgsqlAnnotationCodeGenerator.cs
+++ b/src/EFCore.PG/Design/Internal/NpgsqlAnnotationCodeGenerator.cs
@@ -14,9 +14,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Design.Internal
     public class NpgsqlAnnotationCodeGenerator : AnnotationCodeGenerator
     {
         public NpgsqlAnnotationCodeGenerator([NotNull] AnnotationCodeGeneratorDependencies dependencies)
-            : base(dependencies)
-        {
-        }
+            : base(dependencies) {}
 
         public override bool IsHandledByConvention(IModel model, IAnnotation annotation)
         {
@@ -86,6 +84,20 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Design.Internal
                         enumTypeDef.Name, enumTypeDef.Labels)
                     : new MethodCallCodeFragment(nameof(NpgsqlModelBuilderExtensions.ForNpgsqlHasEnum),
                         enumTypeDef.Schema, enumTypeDef.Name, enumTypeDef.Labels);
+            }
+
+            if (annotation.Name.StartsWith(NpgsqlAnnotationNames.RangePrefix))
+            {
+                var rangeTypeDef = new PostgresRange(model, annotation.Name);
+
+                return new MethodCallCodeFragment(nameof(NpgsqlModelBuilderExtensions.ForNpgsqlHasRange),
+                    rangeTypeDef.Schema == "public" ? null : rangeTypeDef.Schema,
+                    rangeTypeDef.Name,
+                    rangeTypeDef.Subtype,
+                    rangeTypeDef.CanonicalFunction,
+                    rangeTypeDef.SubtypeOpClass,
+                    rangeTypeDef.Collation,
+                    rangeTypeDef.SubtypeDiff);
             }
 
             return null;

--- a/src/EFCore.PG/Infrastructure/Internal/NpgsqlOptionsExtension.cs
+++ b/src/EFCore.PG/Infrastructure/Internal/NpgsqlOptionsExtension.cs
@@ -207,7 +207,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal
         public string RangeName { get; }
 
         /// <summary>
-        /// The PostgreSQL schema in which the range is defined. If null, the default schema is assumed.
+        /// The PostgreSQL schema in which the range is defined. If null, the default schema is used
+        /// (which is public unless changed on the model).
         /// </summary>
         [CanBeNull]
         public string SchemaName { get; }

--- a/src/EFCore.PG/Infrastructure/Internal/NpgsqlOptionsExtension.cs
+++ b/src/EFCore.PG/Infrastructure/Internal/NpgsqlOptionsExtension.cs
@@ -94,24 +94,28 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal
         /// Returns a copy of the current instance configured with the specified range mapping.
         /// </summary>
         [NotNull]
-        public virtual NpgsqlOptionsExtension WithUserRangeDefinition<TSubtype>(string rangeName, string subtypeName)
-        {
-            var clone = (NpgsqlOptionsExtension)Clone();
-
-            clone._userRangeDefinitions.Add(new UserRangeDefinition(rangeName, typeof(TSubtype), subtypeName));
-
-            return clone;
-        }
+        public virtual NpgsqlOptionsExtension WithUserRangeDefinition<TSubtype>(
+            [NotNull] string rangeName,
+            [CanBeNull] string schemaName = null,
+            [CanBeNull] string subtypeName = null)
+            => WithUserRangeDefinition(rangeName, schemaName, typeof(TSubtype), subtypeName);
 
         /// <summary>
         /// Returns a copy of the current instance configured with the specified range mapping.
         /// </summary>
         [NotNull]
-        public virtual NpgsqlOptionsExtension WithUserRangeDefinition(string rangeName, Type subtypeClrType, string subtypeName)
+        public virtual NpgsqlOptionsExtension WithUserRangeDefinition(
+            [NotNull] string rangeName,
+            [CanBeNull] string schemaName,
+            [NotNull] Type subtypeClrType,
+            [CanBeNull] string subtypeName)
         {
+            Check.NotEmpty(rangeName, nameof(rangeName));
+            Check.NotNull(subtypeClrType, nameof(subtypeClrType));
+
             var clone = (NpgsqlOptionsExtension)Clone();
 
-            clone._userRangeDefinitions.Add(new UserRangeDefinition(rangeName, subtypeClrType, subtypeName));
+            clone._userRangeDefinitions.Add(new UserRangeDefinition(rangeName, schemaName, subtypeClrType, subtypeName));
 
             return clone;
         }
@@ -196,29 +200,52 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal
 
     public class UserRangeDefinition
     {
-        /// <summary>The name of the PostgreSQL range type to be mapped.</summary>
+        /// <summary>
+        /// The name of the PostgreSQL range type to be mapped.
+        /// </summary>
+        [NotNull]
         public string RangeName { get; }
+
+        /// <summary>
+        /// The PostgreSQL schema in which the range is defined.
+        /// </summary>
+        [CanBeNull]
+        public string SchemaName { get; }
+
         /// <summary>
         /// The CLR type of the range's subtype (or element).
         /// The actual mapped type will be an <see cref="NpgsqlRange{T}"/> over this type.
         /// </summary>
+        [NotNull]
         public Type SubtypeClrType { get; }
+
         /// <summary>
         /// Optionally, the name of the range's PostgreSQL subtype (or element).
         /// This is usually not needed - the subtype will be inferred based on <see cref="SubtypeClrType"/>.
         /// </summary>
+        [CanBeNull]
         public string SubtypeName { get; }
 
-        public UserRangeDefinition(string rangeName, Type subtypeClrType, string subtypeName)
+        public UserRangeDefinition(
+            [NotNull] string rangeName,
+            [CanBeNull] string schemaName,
+            [NotNull] Type subtypeClrType,
+            [CanBeNull] string subtypeName)
         {
-            RangeName = rangeName;
-            SubtypeClrType = subtypeClrType;
+            RangeName = Check.NotEmpty(rangeName, nameof(rangeName));
+            SchemaName = schemaName;
+            SubtypeClrType = Check.NotNull(subtypeClrType, nameof(subtypeClrType));
             SubtypeName = subtypeName;
         }
 
-        public void Deconstruct(out string rangeName, out Type subtypeClrType, out string subtypeName)
+        public void Deconstruct(
+            [NotNull] out string rangeName,
+            [CanBeNull] out string schemaName,
+            [NotNull] out Type subtypeClrType,
+            [CanBeNull] out string subtypeName)
         {
             rangeName = RangeName;
+            schemaName = SchemaName;
             subtypeClrType = SubtypeClrType;
             subtypeName = SubtypeName;
         }

--- a/src/EFCore.PG/Infrastructure/Internal/NpgsqlOptionsExtension.cs
+++ b/src/EFCore.PG/Infrastructure/Internal/NpgsqlOptionsExtension.cs
@@ -207,7 +207,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal
         public string RangeName { get; }
 
         /// <summary>
-        /// The PostgreSQL schema in which the range is defined.
+        /// The PostgreSQL schema in which the range is defined. If null, the default schema is assumed.
         /// </summary>
         [CanBeNull]
         public string SchemaName { get; }

--- a/src/EFCore.PG/Infrastructure/NpgsqlDbContextOptionsBuilder.cs
+++ b/src/EFCore.PG/Infrastructure/NpgsqlDbContextOptionsBuilder.cs
@@ -45,6 +45,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure
         /// The actual mapped type will be an <see cref="NpgsqlRange{T}"/> over this type.
         /// </typeparam>
         /// <param name="rangeName">The name of the PostgreSQL range type to be mapped.</param>
+        /// <param name="schemaName">The name of the PostgreSQL schema in which the range is defined.</param>
         /// <param name="subtypeName">
         /// Optionally, the name of the range's PostgreSQL subtype (or element).
         /// This is usually not needed - the subtype will be inferred based on <typeparamref name="TSubtype"/>.
@@ -53,13 +54,14 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure
         /// To map a range of PostgreSQL real, use the following:
         /// <code>NpgsqlTypeMappingSource.MapRange{float}("floatrange");</code>
         /// </example>
-        public virtual void MapRange<TSubtype>([NotNull] string rangeName, string subtypeName = null)
-            => WithOption(e => e.WithUserRangeDefinition(rangeName, typeof(TSubtype), subtypeName));
+        public virtual void MapRange<TSubtype>([NotNull] string rangeName, string schemaName = null, string subtypeName = null)
+            => MapRange(rangeName, typeof(TSubtype), schemaName, subtypeName);
 
         /// <summary>
         /// Maps a user-defined PostgreSQL range type for use.
         /// </summary>
         /// <param name="rangeName">The name of the PostgreSQL range type to be mapped.</param>
+        /// <param name="schemaName">The name of the PostgreSQL schema in which the range is defined.</param>
         /// <param name="subtypeClrType">
         /// The CLR type of the range's subtype (or element).
         /// The actual mapped type will be an <see cref="NpgsqlRange{T}"/> over this type.
@@ -72,8 +74,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure
         /// To map a range of PostgreSQL real, use the following:
         /// <code>NpgsqlTypeMappingSource.MapRange("floatrange", typeof(float));</code>
         /// </example>
-        public virtual void MapRange([NotNull] string rangeName, [NotNull] Type subtypeClrType, string subtypeName = null)
-            => WithOption(e => e.WithUserRangeDefinition(rangeName, subtypeClrType, subtypeName));
+        public virtual void MapRange([NotNull] string rangeName, [NotNull] Type subtypeClrType, string schemaName = null, string subtypeName = null)
+            => WithOption(e => e.WithUserRangeDefinition(rangeName, schemaName, subtypeClrType, subtypeName));
 
         /// <summary>
         /// Appends NULLS FIRST to all ORDER BY clauses. This is important for the tests which were written

--- a/src/EFCore.PG/Metadata/PostgresRange.cs
+++ b/src/EFCore.PG/Metadata/PostgresRange.cs
@@ -53,23 +53,19 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata
         }
 
         [NotNull]
-        static string BuildAnnotationName(IAnnotatable annotatable, string schema, string name)
-        {
-            if (!string.IsNullOrEmpty(schema))
-                return $"{NpgsqlAnnotationNames.RangePrefix}{schema}.{name}";
-
-            if (annotatable[RelationalAnnotationNames.DefaultSchema] is string defaultSchema && !string.IsNullOrEmpty(defaultSchema))
-                return $"{NpgsqlAnnotationNames.RangePrefix}{defaultSchema}.{name}";
-
-            return $"{NpgsqlAnnotationNames.RangePrefix}{name}";
-        }
+        static string BuildAnnotationName([NotNull] IAnnotatable annotatable, [CanBeNull] string schema, [NotNull] string name)
+            => !string.IsNullOrEmpty(schema)
+                ? $"{NpgsqlAnnotationNames.RangePrefix}{schema}.{name}"
+                : annotatable[RelationalAnnotationNames.DefaultSchema] is string defaultSchema && !string.IsNullOrEmpty(defaultSchema)
+                    ? $"{NpgsqlAnnotationNames.RangePrefix}{defaultSchema}.{name}"
+                    : $"{NpgsqlAnnotationNames.RangePrefix}{name}";
 
         [NotNull]
         public static IEnumerable<PostgresRange> GetPostgresRanges([NotNull] IAnnotatable annotatable)
             => Check.NotNull(annotatable, nameof(annotatable))
-                .GetAnnotations()
-                .Where(a => a.Name.StartsWith(NpgsqlAnnotationNames.RangePrefix, StringComparison.Ordinal))
-                .Select(a => new PostgresRange(annotatable, a.Name));
+                    .GetAnnotations()
+                    .Where(a => a.Name.StartsWith(NpgsqlAnnotationNames.RangePrefix, StringComparison.Ordinal))
+                    .Select(a => new PostgresRange(annotatable, a.Name));
 
         [NotNull]
         public Annotatable Annotatable => (Annotatable)_annotatable;

--- a/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
@@ -787,7 +787,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations
             // Schemas are normally created (or rather ensured) by the model differ, which scans all tables, sequences
             // and other database objects. However, it isn't aware of ranges, so we always ensure schema on range creation.
             if (rangeType.Schema != null)
-                Generate(new EnsureSchemaOperation { Name=rangeType.Schema }, model, builder);
+                Generate(new EnsureSchemaOperation { Name = rangeType.Schema }, model, builder);
 
             builder
                 .Append("CREATE TYPE ")

--- a/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
@@ -640,10 +640,6 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations
             Check.NotNull(operation, nameof(operation));
             Check.NotNull(builder, nameof(builder));
 
-            // Alter operations may not have a default schema attached. If not, try to attach one for schema-qualified types.
-            if (operation[RelationalAnnotationNames.DefaultSchema] == null)
-                operation[RelationalAnnotationNames.DefaultSchema] = model[RelationalAnnotationNames.DefaultSchema];
-
             GenerateEnumStatements(operation, model, builder);
             GenerateRangeStatements(operation, model, builder);
 

--- a/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
@@ -640,6 +640,10 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations
             Check.NotNull(operation, nameof(operation));
             Check.NotNull(builder, nameof(builder));
 
+            // Alter operations may not have a default schema attached. If not, try to attach one for schema-qualified types.
+            if (operation[RelationalAnnotationNames.DefaultSchema] == null)
+                operation[RelationalAnnotationNames.DefaultSchema] = model[RelationalAnnotationNames.DefaultSchema];
+
             GenerateEnumStatements(operation, model, builder);
             GenerateRangeStatements(operation, model, builder);
 

--- a/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlRangeTypeMapping.cs
+++ b/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlRangeTypeMapping.cs
@@ -10,21 +10,43 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
 {
     public class NpgsqlRangeTypeMapping : NpgsqlTypeMapping
     {
+        [NotNull] readonly ISqlGenerationHelper _sqlGenerationHelper;
+
         public RelationalTypeMapping SubtypeMapping { get; }
 
         public NpgsqlRangeTypeMapping(
             [NotNull] string storeType,
             [NotNull] Type clrType,
-            [NotNull] RelationalTypeMapping subtypeMapping)
-            : base(storeType, clrType, GenerateNpgsqlDbType(subtypeMapping))
-        => SubtypeMapping = subtypeMapping;
+            [NotNull] RelationalTypeMapping subtypeMapping,
+            [NotNull] ISqlGenerationHelper sqlGenerationHelper)
+            : this(storeType, null, clrType, subtypeMapping, sqlGenerationHelper) {}
 
-        protected NpgsqlRangeTypeMapping(RelationalTypeMappingParameters parameters, NpgsqlDbType npgsqlDbType)
-            : base(parameters, npgsqlDbType) { }
+        public NpgsqlRangeTypeMapping(
+            [NotNull] string storeType,
+            [CanBeNull] string storeTypeSchema,
+            [NotNull] Type clrType,
+            [NotNull] RelationalTypeMapping subtypeMapping,
+            [NotNull] ISqlGenerationHelper sqlGenerationHelper)
+            : base(sqlGenerationHelper.DelimitIdentifier(storeType, storeTypeSchema), clrType, GenerateNpgsqlDbType(subtypeMapping))
+        {
+            SubtypeMapping = subtypeMapping;
+            _sqlGenerationHelper = sqlGenerationHelper;
+        }
+
+        protected NpgsqlRangeTypeMapping(
+            RelationalTypeMappingParameters parameters,
+            NpgsqlDbType npgsqlDbType,
+            [NotNull] RelationalTypeMapping subtypeMapping,
+            [NotNull] ISqlGenerationHelper sqlGenerationHelper)
+            : base(parameters, npgsqlDbType)
+        {
+            SubtypeMapping = subtypeMapping;
+            _sqlGenerationHelper = sqlGenerationHelper;
+        }
 
         [NotNull]
         protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
-            => new NpgsqlRangeTypeMapping(parameters, NpgsqlDbType);
+            => new NpgsqlRangeTypeMapping(parameters, NpgsqlDbType, SubtypeMapping, _sqlGenerationHelper);
 
         protected override string GenerateNonNullSqlLiteral(object value)
         {

--- a/test/EFCore.PG.FunctionalTests/Query/RangeQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/RangeQueryNpgsqlTest.cs
@@ -27,9 +27,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
         [MemberData(nameof(RangeTheoryData))]
         public void RangeContainsRange(NpgsqlRange<int> range)
         {
-            using (RangeContext context = Fixture.CreateContext())
+            using (var context = Fixture.CreateContext())
             {
-                RangeTestEntity[] _ =
+                var _ =
                     context.RangeTestEntities
                            .Where(x => x.Range.Contains(range))
                            .ToArray();
@@ -45,9 +45,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
         [MemberData(nameof(RangeTheoryData))]
         public void RangeDoesNotContainRange(NpgsqlRange<int> range)
         {
-            using (RangeContext context = Fixture.CreateContext())
+            using (var context = Fixture.CreateContext())
             {
-                RangeTestEntity[] _ =
+                var _ =
                     context.RangeTestEntities
                            .Where(x => !x.Range.Contains(range))
                            .ToArray();
@@ -63,9 +63,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
         [MemberData(nameof(IntegerTheoryData))]
         public void RangeContainsValue(int value)
         {
-            using (RangeContext context = Fixture.CreateContext())
+            using (var context = Fixture.CreateContext())
             {
-                RangeTestEntity[] _ =
+                var _ =
                     context.RangeTestEntities
                            .Where(x => x.Range.Contains(value))
                            .ToArray();
@@ -81,9 +81,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
         [MemberData(nameof(IntegerTheoryData))]
         public void RangeDoesNotContainValue(int value)
         {
-            using (RangeContext context = Fixture.CreateContext())
+            using (var context = Fixture.CreateContext())
             {
-                RangeTestEntity[] _ =
+                var _ =
                     context.RangeTestEntities
                            .Where(x => !x.Range.Contains(value))
                            .ToArray();
@@ -99,9 +99,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
         [MemberData(nameof(RangeTheoryData))]
         public void RangeContainedByRange(NpgsqlRange<int> range)
         {
-            using (RangeContext context = Fixture.CreateContext())
+            using (var context = Fixture.CreateContext())
             {
-                RangeTestEntity[] _ =
+                var _ =
                     context.RangeTestEntities
                            .Where(x => range.ContainedBy(x.Range))
                            .ToArray();
@@ -117,9 +117,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
         [MemberData(nameof(RangeTheoryData))]
         public void RangeNotContainedByRange(NpgsqlRange<int> range)
         {
-            using (RangeContext context = Fixture.CreateContext())
+            using (var context = Fixture.CreateContext())
             {
-                RangeTestEntity[] _ =
+                var _ =
                     context.RangeTestEntities
                            .Where(x => !range.ContainedBy(x.Range))
                            .ToArray();
@@ -135,9 +135,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
         [MemberData(nameof(RangeTheoryData))]
         public void RangeEqualsRange_Operator(NpgsqlRange<int> range)
         {
-            using (RangeContext context = Fixture.CreateContext())
+            using (var context = Fixture.CreateContext())
             {
-                RangeTestEntity[] _ =
+                var _ =
                     context.RangeTestEntities
                            .Where(x => x.Range == range)
                            .ToArray();
@@ -153,9 +153,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
         [MemberData(nameof(RangeTheoryData))]
         public void RangeEqualsRange_Method(NpgsqlRange<int> range)
         {
-            using (RangeContext context = Fixture.CreateContext())
+            using (var context = Fixture.CreateContext())
             {
-                RangeTestEntity[] _ =
+                var _ =
                     context.RangeTestEntities
                            .Where(x => x.Range.Equals(range))
                            .ToArray();
@@ -171,9 +171,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
         [MemberData(nameof(RangeTheoryData))]
         public void RangeDoesNotEqualsRange_Operator(NpgsqlRange<int> range)
         {
-            using (RangeContext context = Fixture.CreateContext())
+            using (var context = Fixture.CreateContext())
             {
-                RangeTestEntity[] _ =
+                var _ =
                     context.RangeTestEntities
                            .Where(x => x.Range != range)
                            .ToArray();
@@ -189,9 +189,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
         [MemberData(nameof(RangeTheoryData))]
         public void RangeDoesNotEqualsRange_Method(NpgsqlRange<int> range)
         {
-            using (RangeContext context = Fixture.CreateContext())
+            using (var context = Fixture.CreateContext())
             {
-                RangeTestEntity[] _ =
+                var _ =
                     context.RangeTestEntities
                            .Where(x => !x.Range.Equals(range))
                            .ToArray();
@@ -205,11 +205,11 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
         /// </summary>
         [Theory]
         [MemberData(nameof(RangeTheoryData))]
-        public void RangeOvelapsRange(NpgsqlRange<int> range)
+        public void RangeOverlapsRange(NpgsqlRange<int> range)
         {
-            using (RangeContext context = Fixture.CreateContext())
+            using (var context = Fixture.CreateContext())
             {
-                RangeTestEntity[] _ =
+                var _ =
                     context.RangeTestEntities
                            .Where(x => x.Range.Overlaps(range))
                            .ToArray();
@@ -223,11 +223,11 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
         /// </summary>
         [Theory]
         [MemberData(nameof(RangeTheoryData))]
-        public void RangeDoesNotOvelapRange(NpgsqlRange<int> range)
+        public void RangeDoesNotOverlapRange(NpgsqlRange<int> range)
         {
-            using (RangeContext context = Fixture.CreateContext())
+            using (var context = Fixture.CreateContext())
             {
-                RangeTestEntity[] _ =
+                var _ =
                     context.RangeTestEntities
                            .Where(x => !x.Range.Overlaps(range))
                            .ToArray();
@@ -243,9 +243,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
         [MemberData(nameof(RangeTheoryData))]
         public void RangeIsStrictlyLeftOfRange(NpgsqlRange<int> range)
         {
-            using (RangeContext context = Fixture.CreateContext())
+            using (var context = Fixture.CreateContext())
             {
-                RangeTestEntity[] _ =
+                var _ =
                     context.RangeTestEntities
                            .Where(x => x.Range.IsStrictlyLeftOf(range))
                            .ToArray();
@@ -261,9 +261,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
         [MemberData(nameof(RangeTheoryData))]
         public void RangeIsNotStrictlyLeftOfRange(NpgsqlRange<int> range)
         {
-            using (RangeContext context = Fixture.CreateContext())
+            using (var context = Fixture.CreateContext())
             {
-                RangeTestEntity[] _ =
+                var _ =
                     context.RangeTestEntities
                            .Where(x => !x.Range.IsStrictlyLeftOf(range))
                            .ToArray();
@@ -279,9 +279,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
         [MemberData(nameof(RangeTheoryData))]
         public void RangeIsStrictlyRightOfRange(NpgsqlRange<int> range)
         {
-            using (RangeContext context = Fixture.CreateContext())
+            using (var context = Fixture.CreateContext())
             {
-                RangeTestEntity[] _ =
+                var _ =
                     context.RangeTestEntities
                            .Where(x => x.Range.IsStrictlyRightOf(range))
                            .ToArray();
@@ -297,9 +297,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
         [MemberData(nameof(RangeTheoryData))]
         public void RangeIsNotStrictlyRightOfRange(NpgsqlRange<int> range)
         {
-            using (RangeContext context = Fixture.CreateContext())
+            using (var context = Fixture.CreateContext())
             {
-                RangeTestEntity[] _ =
+                var _ =
                     context.RangeTestEntities
                            .Where(x => !x.Range.IsStrictlyRightOf(range))
                            .ToArray();
@@ -315,9 +315,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
         [MemberData(nameof(RangeTheoryData))]
         public void RangeDoesNotExtendLeftOfRange(NpgsqlRange<int> range)
         {
-            using (RangeContext context = Fixture.CreateContext())
+            using (var context = Fixture.CreateContext())
             {
-                RangeTestEntity[] _ =
+                var _ =
                     context.RangeTestEntities
                            .Where(x => x.Range.DoesNotExtendLeftOf(range))
                            .ToArray();
@@ -333,9 +333,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
         [MemberData(nameof(RangeTheoryData))]
         public void RangeDoesExtendLeftOfRange(NpgsqlRange<int> range)
         {
-            using (RangeContext context = Fixture.CreateContext())
+            using (var context = Fixture.CreateContext())
             {
-                RangeTestEntity[] _ =
+                var _ =
                     context.RangeTestEntities
                            .Where(x => !x.Range.DoesNotExtendLeftOf(range))
                            .ToArray();
@@ -351,9 +351,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
         [MemberData(nameof(RangeTheoryData))]
         public void RangeDoesNotExtendRightOfRange(NpgsqlRange<int> range)
         {
-            using (RangeContext context = Fixture.CreateContext())
+            using (var context = Fixture.CreateContext())
             {
-                RangeTestEntity[] _ =
+                var _ =
                     context.RangeTestEntities
                            .Where(x => x.Range.DoesNotExtendRightOf(range))
                            .ToArray();
@@ -369,9 +369,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
         [MemberData(nameof(RangeTheoryData))]
         public void RangeDoesExtendRightOfRange(NpgsqlRange<int> range)
         {
-            using (RangeContext context = Fixture.CreateContext())
+            using (var context = Fixture.CreateContext())
             {
-                RangeTestEntity[] _ =
+                var _ =
                     context.RangeTestEntities
                            .Where(x => !x.Range.DoesNotExtendRightOf(range))
                            .ToArray();
@@ -387,9 +387,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
         [MemberData(nameof(RangeTheoryData))]
         public void RangeIsAdjacentToRange(NpgsqlRange<int> range)
         {
-            using (RangeContext context = Fixture.CreateContext())
+            using (var context = Fixture.CreateContext())
             {
-                RangeTestEntity[] _ =
+                var _ =
                     context.RangeTestEntities
                            .Where(x => x.Range.IsAdjacentTo(range))
                            .ToArray();
@@ -405,9 +405,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
         [MemberData(nameof(RangeTheoryData))]
         public void RangeIsNotAdjacentToRange(NpgsqlRange<int> range)
         {
-            using (RangeContext context = Fixture.CreateContext())
+            using (var context = Fixture.CreateContext())
             {
-                RangeTestEntity[] _ =
+                var _ =
                     context.RangeTestEntities
                            .Where(x => !x.Range.IsAdjacentTo(range))
                            .ToArray();
@@ -423,9 +423,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
         [MemberData(nameof(RangeTheoryData))]
         public void RangeUnionRange(NpgsqlRange<int> range)
         {
-            using (RangeContext context = Fixture.CreateContext())
+            using (var context = Fixture.CreateContext())
             {
-                NpgsqlRange<int>[] _ =
+                var _ =
                     context.RangeTestEntities
                            .Select(x => x.Range.Union(range))
                            .ToArray();
@@ -441,9 +441,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
         [MemberData(nameof(RangeTheoryData))]
         public void RangeIntersectsRange(NpgsqlRange<int> range)
         {
-            using (RangeContext context = Fixture.CreateContext())
+            using (var context = Fixture.CreateContext())
             {
-                NpgsqlRange<int>[] _ =
+                var _ =
                     context.RangeTestEntities
                            .Select(x => x.Range.Intersect(range))
                            .ToArray();
@@ -459,11 +459,11 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
         [MemberData(nameof(RangeTheoryData))]
         public void RangeExceptRange(NpgsqlRange<int> range)
         {
-            using (RangeContext context = Fixture.CreateContext())
+            using (var context = Fixture.CreateContext())
             {
                 try
                 {
-                    NpgsqlRange<int>[] _ =
+                    var _ =
                         context.RangeTestEntities
                                .Select(x => x.Range.Except(range))
                                .ToArray();
@@ -484,7 +484,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
         [Fact]
         public void UserDefined()
         {
-            using (RangeContext context = Fixture.CreateContext())
+            using (var context = Fixture.CreateContext())
             {
                 var e = context.RangeTestEntities.Single(x => x.FloatRange.UpperBound > 5);
                 Assert.Equal(e.FloatRange.LowerBound, 0);
@@ -495,7 +495,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
         [Fact]
         public void UserDefinedSchemaQualified()
         {
-            using (RangeContext context = Fixture.CreateContext())
+            using (var context = Fixture.CreateContext())
             {
                 var e = context.RangeTestEntities.Single(x => x.SchemaRange == NpgsqlRange<double>.Parse("(0,10)"));
                 AssertContainsSql("WHERE x.\"SchemaRange\" = @__Parse_0");
@@ -511,7 +511,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
         [Fact]
         public void RangeLowerBound()
         {
-            using (RangeContext context = Fixture.CreateContext())
+            using (var context = Fixture.CreateContext())
             {
                 try
                 {
@@ -529,7 +529,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
         [Fact]
         public void RangeUpperBound()
         {
-            using (RangeContext context = Fixture.CreateContext())
+            using (var context = Fixture.CreateContext())
             {
                 var _ = context.RangeTestEntities.Select(x => x.Range.UpperBound).ToArray();
                 AssertContainsSql("SELECT COALESCE(upper(x.\"Range\"), 0)");
@@ -539,7 +539,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
         [Fact]
         public void RangeIsEmpty()
         {
-            using (RangeContext context = Fixture.CreateContext())
+            using (var context = Fixture.CreateContext())
             {
                 var _ = context.RangeTestEntities.Select(x => x.Range.IsEmpty).ToArray();
                 AssertContainsSql("SELECT isempty(x.\"Range\")");
@@ -549,7 +549,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
         [Fact]
         public void RangeLowerBoundIsInclusive()
         {
-            using (RangeContext context = Fixture.CreateContext())
+            using (var context = Fixture.CreateContext())
             {
                 var _ = context.RangeTestEntities.Select(x => x.Range.LowerBoundIsInclusive).ToArray();
                 AssertContainsSql("SELECT lower_inc(x.\"Range\")");
@@ -559,7 +559,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
         [Fact]
         public void RangeUpperBoundIsInclusive()
         {
-            using (RangeContext context = Fixture.CreateContext())
+            using (var context = Fixture.CreateContext())
             {
                 var _ = context.RangeTestEntities.Select(x => x.Range.UpperBoundIsInclusive).ToArray();
                 AssertContainsSql("SELECT upper_inc(x.\"Range\")");
@@ -569,7 +569,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
         [Fact]
         public void RangeLowerBoundInfinite()
         {
-            using (RangeContext context = Fixture.CreateContext())
+            using (var context = Fixture.CreateContext())
             {
                 var _ = context.RangeTestEntities.Select(x => x.Range.LowerBoundInfinite).ToArray();
                 AssertContainsSql("SELECT lower_inf(x.\"Range\")");
@@ -579,7 +579,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
         [Fact]
         public void RangeUpperBoundInfinite()
         {
-            using (RangeContext context = Fixture.CreateContext())
+            using (var context = Fixture.CreateContext())
             {
                 var _ = context.RangeTestEntities.Select(x => x.Range.UpperBoundInfinite).ToArray();
                 AssertContainsSql("SELECT upper_inf(x.\"Range\")");
@@ -589,7 +589,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
         [Fact]
         public void RangeMergeRange()
         {
-            using (RangeContext context = Fixture.CreateContext())
+            using (var context = Fixture.CreateContext())
             {
                 var _ = context.RangeTestEntities.Select(x => x.Range.Merge(x.Range)).ToArray();
                 AssertContainsSql("SELECT range_merge(x.\"Range\", x.\"Range\")");
@@ -697,7 +697,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
                                 .BuildServiceProvider())
                         .Options;
 
-                using (RangeContext context = CreateContext())
+                using (var context = CreateContext())
                 {
                     context.Database.EnsureCreated();
 
@@ -757,16 +757,10 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             /// <returns>
             /// A <see cref="RangeContext"/> for testing.
             /// </returns>
-            public RangeContext CreateContext()
-            {
-                return new RangeContext(_options);
-            }
+            public RangeContext CreateContext() => new RangeContext(_options);
 
             /// <inheritdoc />
-            public void Dispose()
-            {
-                _testStore.Dispose();
-            }
+            public void Dispose() => _testStore.Dispose();
         }
 
         public class RangeTestEntity
@@ -809,10 +803,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
         /// Asserts that the SQL fragment appears in the logs.
         /// </summary>
         /// <param name="sql">The SQL statement or fragment to search for in the logs.</param>
-        public void AssertContainsSql(string sql)
-        {
-            Assert.Contains(sql, Fixture.TestSqlLoggerFactory.Sql);
-        }
+        void AssertContainsSql(string sql) => Assert.Contains(sql, Fixture.TestSqlLoggerFactory.Sql);
 
         #endregion
     }

--- a/test/EFCore.PG.FunctionalTests/Scaffolding/NpgsqlDatabaseModelFactoryTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Scaffolding/NpgsqlDatabaseModelFactoryTest.cs
@@ -1763,6 +1763,7 @@ CREATE TABLE column_types (
                             Array.Empty<ITypeMappingSourcePlugin>()
                         ),
                         new RelationalTypeMappingSourceDependencies(Array.Empty<IRelationalTypeMappingSourcePlugin>()),
+                        new NpgsqlSqlGenerationHelper(new RelationalSqlGenerationHelperDependencies()),
                         options
                     );
 

--- a/test/EFCore.PG.Plugins.FunctionalTests/NpgsqlNodaTimeTypeMappingTest.cs
+++ b/test/EFCore.PG.Plugins.FunctionalTests/NpgsqlNodaTimeTypeMappingTest.cs
@@ -118,7 +118,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL
 
         #region Support
 
-        static readonly IRelationalTypeMappingSourcePlugin Mapper = new NpgsqlNodaTimeTypeMappingSourcePlugin();
+        static readonly IRelationalTypeMappingSourcePlugin Mapper =
+            new NpgsqlNodaTimeTypeMappingSourcePlugin(new NpgsqlSqlGenerationHelper(new RelationalSqlGenerationHelperDependencies()));
 
         static RelationalTypeMapping GetMapping(string storeType)
             => Mapper.FindMapping(new RelationalTypeMappingInfo(storeType));

--- a/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingSourceTest.cs
+++ b/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingSourceTest.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
@@ -63,8 +62,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage
         public NpgsqlTypeMappingSourceTest()
         {
             var builder = new DbContextOptionsBuilder();
-            new NpgsqlDbContextOptionsBuilder(builder).MapRange("floatrange", typeof(float));
-            new NpgsqlDbContextOptionsBuilder(builder).MapRange("dummyrange", typeof(DummyType), "dummy");
+            new NpgsqlDbContextOptionsBuilder(builder).MapRange<float>("floatrange");
+            new NpgsqlDbContextOptionsBuilder(builder).MapRange<DummyType>("dummyrange", subtypeName: "dummy");
             var options = new NpgsqlOptions();
             options.Initialize(builder.Options);
 
@@ -74,6 +73,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage
                     Array.Empty<ITypeMappingSourcePlugin>()),
                 new RelationalTypeMappingSourceDependencies(
                     new[] { new DummyTypeMappingSourcePlugin() }),
+                new NpgsqlSqlGenerationHelper(new RelationalSqlGenerationHelperDependencies()),
                 options);
         }
 

--- a/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingTest.cs
+++ b/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingTest.cs
@@ -432,6 +432,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage
                 Array.Empty<ITypeMappingSourcePlugin>()
             ),
             new RelationalTypeMappingSourceDependencies(Array.Empty<IRelationalTypeMappingSourcePlugin>()),
+            new NpgsqlSqlGenerationHelper(new RelationalSqlGenerationHelperDependencies()),
             new NpgsqlOptions()
         );
 

--- a/test/EFCore.PG.Tests/Update/NpgsqlModificationCommandBatchFactoryTest.cs
+++ b/test/EFCore.PG.Tests/Update/NpgsqlModificationCommandBatchFactoryTest.cs
@@ -27,6 +27,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Update
                     Array.Empty<ITypeMappingSourcePlugin>()
                 ),
                 new RelationalTypeMappingSourceDependencies(Array.Empty<IRelationalTypeMappingSourcePlugin>()),
+                new NpgsqlSqlGenerationHelper(new RelationalSqlGenerationHelperDependencies()),
                 new NpgsqlOptions()
             );
             var factory = new NpgsqlModificationCommandBatchFactory(
@@ -63,6 +64,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Update
                     Array.Empty<ITypeMappingSourcePlugin>()
                 ),
                 new RelationalTypeMappingSourceDependencies(Array.Empty<IRelationalTypeMappingSourcePlugin>()),
+                new NpgsqlSqlGenerationHelper(new RelationalSqlGenerationHelperDependencies()),
                 new NpgsqlOptions()
             );
             var factory = new NpgsqlModificationCommandBatchFactory(

--- a/test/EFCore.PG.Tests/Update/NpgsqlModificationCommandBatchTest.cs
+++ b/test/EFCore.PG.Tests/Update/NpgsqlModificationCommandBatchTest.cs
@@ -24,6 +24,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Tests.Update
                     Array.Empty<ITypeMappingSourcePlugin>()
                 ),
                 new RelationalTypeMappingSourceDependencies(Array.Empty<IRelationalTypeMappingSourcePlugin>()),
+                new NpgsqlSqlGenerationHelper(new RelationalSqlGenerationHelperDependencies()),
                 new NpgsqlOptions()
             );
 


### PR DESCRIPTION
## Changes
- If no schema is specified in `.ForNpgsqlHasRange(...)`, then use the default schema annotation.
- Properly quote schema-qualified ranges for literal generation and mapping (override `StoreType`).
