### PR TITLE
Target EF Core v2.1.3

### DIFF
--- a/src/EFCore.PG/EFCore.PG.csproj
+++ b/src/EFCore.PG/EFCore.PG.csproj
@@ -22,9 +22,9 @@
   <ItemGroup>
     <!-- PrivateAssets="none" is set to flow the EF Core analyzer to users referencing this package
 	 https://github.com/aspnet/EntityFrameworkCore/pull/11350 -->
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.1.2" PrivateAssets="none" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.1.2" PrivateAssets="none" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="2.1.2" PrivateAssets="none" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.1.3" PrivateAssets="none" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.1.3" PrivateAssets="none" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="2.1.3" PrivateAssets="none" />
     <PackageReference Include="Npgsql" Version="4.0.3" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
I'm seeing package downgrade errors while publishing self-contained apps that reference the Npgsql provider. 

Bumping the dependencies to `2.1.3` for `hotfix/2.1.3`.