### PR TITLE
Add support for index operators

### DIFF
--- a/src/EFCore.PG/Design/Internal/NpgsqlAnnotationCodeGenerator.cs
+++ b/src/EFCore.PG/Design/Internal/NpgsqlAnnotationCodeGenerator.cs
@@ -135,6 +135,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Design.Internal
         {
             if (annotation.Name == NpgsqlAnnotationNames.IndexMethod)
                 return new MethodCallCodeFragment(nameof(NpgsqlIndexBuilderExtensions.ForNpgsqlHasMethod), annotation.Value);
+            if (annotation.Name == NpgsqlAnnotationNames.IndexOperators)
+                return new MethodCallCodeFragment(nameof(NpgsqlIndexBuilderExtensions.ForNpgsqlHasOperators), annotation.Value);
 
             return null;
         }

--- a/src/EFCore.PG/Extensions/NpgsqlIndexBuilderExtensions.cs
+++ b/src/EFCore.PG/Extensions/NpgsqlIndexBuilderExtensions.cs
@@ -28,5 +28,24 @@ namespace Microsoft.EntityFrameworkCore
 
             return indexBuilder;
         }
+
+        /// <summary>
+        /// The PostgreSQL index operators to be used.
+        /// </summary>
+        /// <remarks>
+        /// https://www.postgresql.org/docs/current/static/indexes-opclass.html
+        /// </remarks>
+        /// <param name="indexBuilder"> The builder for the index being configured. </param>
+        /// <param name="operators"> The operators to use for each column. </param>
+        /// <returns> A builder to further configure the index. </returns>
+        public static IndexBuilder ForNpgsqlHasOperators([NotNull] this IndexBuilder indexBuilder, [CanBeNull] params string[] operators)
+        {
+            Check.NotNull(indexBuilder, nameof(indexBuilder));
+            Check.NullButNotEmpty(operators, nameof(operators));
+
+            indexBuilder.Metadata.Npgsql().Operators = operators;
+
+            return indexBuilder;
+        }
     }
 }

--- a/src/EFCore.PG/Metadata/INpgsqlIndexAnnotations.cs
+++ b/src/EFCore.PG/Metadata/INpgsqlIndexAnnotations.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore.Metadata;
+﻿using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata
 {
@@ -18,6 +19,6 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata
         /// <remarks>
         /// https://www.postgresql.org/docs/current/static/indexes-opclass.html
         /// </remarks>
-        string[] Operators { get; }
+        IReadOnlyList<string> Operators { get; }
     }
 }

--- a/src/EFCore.PG/Metadata/INpgsqlIndexAnnotations.cs
+++ b/src/EFCore.PG/Metadata/INpgsqlIndexAnnotations.cs
@@ -11,5 +11,13 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata
         /// http://www.postgresql.org/docs/current/static/sql-createindex.html
         /// </remarks>
         string Method { get; }
+
+        /// <summary>
+        /// The PostgreSQL index operators to be used.
+        /// </summary>
+        /// <remarks>
+        /// https://www.postgresql.org/docs/current/static/indexes-opclass.html
+        /// </remarks>
+        string[] Operators { get; }
     }
 }

--- a/src/EFCore.PG/Metadata/Internal/NpgsqlAnnotationNames.cs
+++ b/src/EFCore.PG/Metadata/Internal/NpgsqlAnnotationNames.cs
@@ -10,6 +10,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.Internal
         public const string HiLoSequenceName = Prefix + "HiLoSequenceName";
         public const string HiLoSequenceSchema = Prefix + "HiLoSequenceSchema";
         public const string IndexMethod = Prefix + "IndexMethod";
+        public const string IndexOperators = Prefix + "IndexOperators";
         public const string PostgresExtensionPrefix = Prefix + "PostgresExtension:";
         public const string EnumPrefix = Prefix + "Enum:";
         public const string RangePrefix = Prefix + "Range:";

--- a/src/EFCore.PG/Metadata/NpgsqlIndexAnnotations.cs
+++ b/src/EFCore.PG/Metadata/NpgsqlIndexAnnotations.cs
@@ -28,8 +28,22 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata
             set => SetMethod(value);
         }
 
+        /// <summary>
+        /// The PostgreSQL index operators to be used.
+        /// </summary>
+        /// <remarks>
+        /// https://www.postgresql.org/docs/current/static/indexes-opclass.html
+        /// </remarks>
+        public string[] Operators
+        {
+            get => (string[]) Annotations.Metadata[NpgsqlAnnotationNames.IndexOperators];
+            set => SetOperators(value);
+        }
+
         protected virtual bool SetMethod(string value)
             => Annotations.SetAnnotation(NpgsqlAnnotationNames.IndexMethod, value);
 
+        protected virtual bool SetOperators(string[] value)
+            => Annotations.SetAnnotation(NpgsqlAnnotationNames.IndexOperators, value);
     }
 }

--- a/src/EFCore.PG/Metadata/NpgsqlIndexAnnotations.cs
+++ b/src/EFCore.PG/Metadata/NpgsqlIndexAnnotations.cs
@@ -1,4 +1,5 @@
-﻿using JetBrains.Annotations;
+﻿using System.Collections.Generic;
+using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.Internal;
 
@@ -39,6 +40,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata
             get => (string[]) Annotations.Metadata[NpgsqlAnnotationNames.IndexOperators];
             set => SetOperators(value);
         }
+
+        IReadOnlyList<string> INpgsqlIndexAnnotations.Operators => Operators;
 
         protected virtual bool SetMethod(string value)
             => Annotations.SetAnnotation(NpgsqlAnnotationNames.IndexMethod, value);

--- a/src/EFCore.PG/Migrations/Internal/NpgsqlMigrationsAnnotationProvider.cs
+++ b/src/EFCore.PG/Migrations/Internal/NpgsqlMigrationsAnnotationProvider.cs
@@ -47,6 +47,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations.Internal
         {
             if (index.Npgsql().Method != null)
                 yield return new Annotation(NpgsqlAnnotationNames.IndexMethod, index.Npgsql().Method);
+            if (index.Npgsql().Operators != null)
+                yield return new Annotation(NpgsqlAnnotationNames.IndexOperators, index.Npgsql().Operators);
         }
 
         public override IEnumerable<IAnnotation> For(IModel model)

--- a/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
@@ -1151,10 +1151,28 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations
                 if (string.IsNullOrEmpty(@operator))
                     return identifier;
 
-                var delimitedOperator = Dependencies.SqlGenerationHelper.DelimitIdentifier(@operator);
+                var delimitedOperator = TryParseSchema(@operator, out var name, out var schema)
+                    ? Dependencies.SqlGenerationHelper.DelimitIdentifier(name, schema)
+                    : Dependencies.SqlGenerationHelper.DelimitIdentifier(@operator);
 
                 return string.Concat(identifier, " ", delimitedOperator);
             }));
+        }
+
+        static bool TryParseSchema(string identifier, out string name, out string schema)
+        {
+            var index = identifier.IndexOf('.');
+
+            if (index >= 0)
+            {
+                schema = identifier.Substring(0, index);
+                name = identifier.Substring(index + 1);
+                return true;
+            }
+
+            schema = default;
+            name = default;
+            return false;
         }
 
         #endregion

--- a/src/EFCore.PG/Utilities/Check.cs
+++ b/src/EFCore.PG/Utilities/Check.cs
@@ -92,6 +92,19 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Utilities
             return value;
         }
 
+        public static IReadOnlyCollection<T> NullButNotEmpty<T>([CanBeNull] IReadOnlyCollection<T> value, [InvokerParameterName] [NotNull] string parameterName)
+        {
+            if (!ReferenceEquals(value, null)
+                && (value.Count == 0))
+            {
+                NotEmpty(parameterName, nameof(parameterName));
+
+                throw new ArgumentException(AbstractionsStrings.ArgumentIsEmpty(parameterName));
+            }
+
+            return value;
+        }
+
         public static IReadOnlyList<T> HasNoNulls<T>(IReadOnlyList<T> value, [InvokerParameterName] [NotNull] string parameterName)
             where T : class
         {

--- a/test/EFCore.PG.FunctionalTests/NpgsqlMigrationSqlGeneratorTest.cs
+++ b/test/EFCore.PG.FunctionalTests/NpgsqlMigrationSqlGeneratorTest.cs
@@ -634,6 +634,23 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL
         }
 
         [Fact]
+        public void CreateIndexOperation_schema_qualified_operations()
+        {
+            Generate(new CreateIndexOperation
+            {
+                Name = "IX_People_Name",
+                Table = "People",
+                Schema = "dbo",
+                Columns = new[] { "FirstName" },
+                [NpgsqlAnnotationNames.IndexOperators] = new[] { "myschema.TextOperation" }
+            });
+
+            Assert.Equal(
+                "CREATE INDEX \"IX_People_Name\" ON dbo.\"People\" (\"FirstName\" myschema.\"TextOperation\");" + EOL,
+                Sql);
+        }
+
+        [Fact]
         public void RenameIndexOperation()
         {
             Generate(

--- a/test/EFCore.PG.FunctionalTests/NpgsqlMigrationSqlGeneratorTest.cs
+++ b/test/EFCore.PG.FunctionalTests/NpgsqlMigrationSqlGeneratorTest.cs
@@ -617,6 +617,23 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL
         }
 
         [Fact]
+        public void CreateIndexOperation_operations()
+        {
+            Generate(new CreateIndexOperation
+            {
+                Name = "IX_People_Name",
+                Table = "People",
+                Schema = "dbo",
+                Columns = new[] { "FirstName", "LastName" },
+                [NpgsqlAnnotationNames.IndexOperators] = new[] { "text_pattern_ops" }
+            });
+
+            Assert.Equal(
+                "CREATE INDEX \"IX_People_Name\" ON dbo.\"People\" (\"FirstName\" text_pattern_ops, \"LastName\");" + EOL,
+                Sql);
+        }
+
+        [Fact]
         public void RenameIndexOperation()
         {
             Generate(


### PR DESCRIPTION
Just picking up the good work done by @quanterion in https://github.com/npgsql/Npgsql.EntityFrameworkCore.PostgreSQL/pull/257.

I tried looking at scaffolding support as well, but it was a bit involved, so figured I'd punt on it for now and focus on getting the runtime support in.

Closes https://github.com/npgsql/Npgsql.EntityFrameworkCore.PostgreSQL/issues/481