### PR TITLE
Cleanup migrations

### DIFF
--- a/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
@@ -519,7 +519,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations
                 name = operation.NewName;
             }
 
-            if (operation.NewSchema != null)
+            if (operation.NewSchema != null &&
+                operation.NewSchema != operation.Schema)
             {
                 Transfer(operation.NewSchema, operation.Schema, name, "TABLE", builder);
             }
@@ -1075,7 +1076,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations
                 .Append(" ")
                 .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(name, schema))
                 .Append(" SET SCHEMA ")
-                .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(newSchema));
+                .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(newSchema))
+                .AppendLine(';');
         }
 
         #endregion Utilities

--- a/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
@@ -489,7 +489,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations
                 name = operation.NewName;
             }
 
-            if (operation.NewSchema != null)
+            if (operation.NewSchema != null &&
+                operation.NewSchema != operation.Schema)
             {
                 Transfer(operation.NewSchema, operation.Schema, name, "SEQUENCE", builder);
             }


### PR DESCRIPTION
This follows #701 with some cleanup:

- Our current implementation doesn't make use of the name + schema overload of `SqlGenerationHelper.DelimitIdentifier` making for an overly verbose implementation. 

- Additionally, the `NpgsqlMigrationsSqlGenerator.Rename` expected _already delimited_ names, while `NpgsqlMigrationsSqlGenerator.Transfer` expected names to _not be delimited_.

- Cosmetically, this removes three annotations that are (now) already included in the base classes, so Rider/ReSharper is happy to let us omit them here. 
