### PR TITLE
Spatial type and SRID annotations

### DIFF
--- a/src/EFCore.PG/Design/Internal/NpgsqlAnnotationCodeGenerator.cs
+++ b/src/EFCore.PG/Design/Internal/NpgsqlAnnotationCodeGenerator.cs
@@ -149,9 +149,16 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Design.Internal
 
             case NpgsqlAnnotationNames.Comment:
                 return new MethodCallCodeFragment(nameof(NpgsqlPropertyBuilderExtensions.ForNpgsqlHasComment), annotation.Value);
-            }
 
-            return null;
+            case NpgsqlAnnotationNames.SpatialType:
+                return new MethodCallCodeFragment(nameof(NpgsqlPropertyBuilderExtensions.ForNpgsqlHasSpatialType), annotation.Value);
+
+            case NpgsqlAnnotationNames.Srid:
+                return new MethodCallCodeFragment(nameof(NpgsqlPropertyBuilderExtensions.ForNpgsqlHasSrid), annotation.Value);
+
+            default:
+                return null;
+            }
         }
 
         public override MethodCallCodeFragment GenerateFluentApi(IIndex index, IAnnotation annotation)

--- a/src/EFCore.PG/Extensions/NpgsqlPropertyBuilderExtensions.cs
+++ b/src/EFCore.PG/Extensions/NpgsqlPropertyBuilderExtensions.cs
@@ -226,9 +226,73 @@ namespace Microsoft.EntityFrameworkCore
         public static PropertyBuilder<TEntity> ForNpgsqlHasComment<TEntity>(
             [NotNull] this PropertyBuilder<TEntity> propertyBuilder,
             [CanBeNull] string comment)
-        => (PropertyBuilder<TEntity>)ForNpgsqlHasComment((PropertyBuilder)propertyBuilder, comment);
+            => (PropertyBuilder<TEntity>)ForNpgsqlHasComment((PropertyBuilder)propertyBuilder, comment);
 
         #endregion Comment
+
+        #region Spatial methods
+
+        /// <summary>
+        /// Configures the spatial type of the column that the property maps to when targeting PostgreSQL.
+        /// </summary>
+        /// <param name="propertyBuilder">The builder for the property being configured.</param>
+        /// <param name="type">The spatial type.</param>
+        /// <returns>
+        /// The same builder instance so that multiple calls can be chained.
+        /// </returns>
+        public static PropertyBuilder ForNpgsqlHasSpatialType([NotNull] this PropertyBuilder propertyBuilder, [CanBeNull] string type)
+        {
+            Check.NotNull(propertyBuilder, nameof(propertyBuilder));
+
+            propertyBuilder.Metadata.Npgsql().SpatialType = type;
+
+            return propertyBuilder;
+        }
+
+        /// <summary>
+        /// Configures the spatial type of the column that the property maps to when targeting PostgreSQL.
+        /// </summary>
+        /// <param name="propertyBuilder">The builder for the property being configured.</param>
+        /// <param name="type">The spatial type.</param>
+        /// <returns>
+        /// The same builder instance so that multiple calls can be chained.
+        /// </returns>
+        public static PropertyBuilder<TProperty> ForNpgsqlHasSpatialType<TProperty>(
+            [NotNull] this PropertyBuilder<TProperty> propertyBuilder,
+            [CanBeNull] string type)
+            => (PropertyBuilder<TProperty>)ForNpgsqlHasSpatialType((PropertyBuilder)propertyBuilder, type);
+
+        /// <summary>
+        /// Configures the SRID of the column that the property maps to when targeting PostgreSQL.
+        /// </summary>
+        /// <param name="propertyBuilder">The builder for the property being configured.</param>
+        /// <param name="srid">The SRID.</param>
+        /// <returns>
+        /// The same builder instance so that multiple calls can be chained.
+        /// </returns>
+        public static PropertyBuilder ForNpgsqlHasSrid([NotNull] this PropertyBuilder propertyBuilder, int srid)
+        {
+            Check.NotNull(propertyBuilder, nameof(propertyBuilder));
+
+            propertyBuilder.Metadata.Npgsql().Srid = srid;
+
+            return propertyBuilder;
+        }
+
+        /// <summary>
+        /// Configures the SRID of the column that the property maps to when targeting PostgreSQL.
+        /// </summary>
+        /// <param name="propertyBuilder">The builder for the property being configured.</param>
+        /// <param name="srid">The SRID.</param>
+        /// <returns>
+        /// The same builder instance so that multiple calls can be chained.
+        /// </returns>
+        public static PropertyBuilder<TProperty> ForNpgsqlHasSrid<TProperty>(
+            [NotNull] this PropertyBuilder<TProperty> propertyBuilder,
+            int srid)
+            => (PropertyBuilder<TProperty>)ForNpgsqlHasSrid((PropertyBuilder)propertyBuilder, srid);
+
+        #endregion
 
         static NpgsqlPropertyBuilderAnnotations GetNpgsqlInternalBuilder(PropertyBuilder propertyBuilder)
             => propertyBuilder.GetInfrastructure<InternalPropertyBuilder>().Npgsql(ConfigurationSource.Explicit);

--- a/src/EFCore.PG/Metadata/INpgsqlPropertyAnnotations.cs
+++ b/src/EFCore.PG/Metadata/INpgsqlPropertyAnnotations.cs
@@ -1,13 +1,29 @@
-﻿using Microsoft.EntityFrameworkCore.Metadata;
+﻿using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata
 {
     public interface INpgsqlPropertyAnnotations : IRelationalPropertyAnnotations
     {
+        [CanBeNull]
         NpgsqlValueGenerationStrategy? ValueGenerationStrategy { get; }
+
+        [CanBeNull]
         string HiLoSequenceName { get; }
+
+        [CanBeNull]
         string HiLoSequenceSchema { get; }
+
+        [CanBeNull]
         ISequence FindHiLoSequence();
+
+        [CanBeNull]
         string Comment { get; }
+
+        [CanBeNull]
+        string SpatialType { get; }
+
+        [CanBeNull]
+        int? Srid { get; }
     }
 }

--- a/src/EFCore.PG/Metadata/Internal/NpgsqlAnnotationNames.cs
+++ b/src/EFCore.PG/Metadata/Internal/NpgsqlAnnotationNames.cs
@@ -19,6 +19,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.Internal
         public const string Tablespace = Prefix + "Tablespace";
         public const string StorageParameterPrefix = Prefix + "StorageParameter:";
         public const string Comment = Prefix + "Comment";
+        public const string SpatialType = Prefix + "SpatialType";
+        public const string Srid = Prefix + "Srid";
 
         // Database model annotations
 

--- a/src/EFCore.PG/Metadata/Internal/NpgsqlPropertyBuilderAnnotations.cs
+++ b/src/EFCore.PG/Metadata/Internal/NpgsqlPropertyBuilderAnnotations.cs
@@ -42,6 +42,18 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.Internal
         /// </summary>
         protected override bool ShouldThrowOnInvalidConfiguration => Annotations.ConfigurationSource == ConfigurationSource.Explicit;
 
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual bool HasSpatialType(string value) => SetSpatialType(value);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual bool HasSrid(int? value) => SetSrid(value);
+
 #pragma warning disable 109
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.PG/Metadata/NpgsqlPropertyAnnotations.cs
+++ b/src/EFCore.PG/Metadata/NpgsqlPropertyAnnotations.cs
@@ -319,5 +319,45 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata
             => Annotations.SetAnnotation(
                 NpgsqlAnnotationNames.Comment,
                 Check.NullButNotEmpty(value, nameof(value)));
+
+        /// <summary>
+        /// Gets or sets the spatial type to use when creating a column for this property.
+        /// </summary>
+        public virtual string SpatialType
+        {
+            get => (string)Annotations.Metadata[NpgsqlAnnotationNames.SpatialType];
+            [param: CanBeNull]
+            set => SetSpatialType(value);
+        }
+
+        /// <summary>
+        /// Sets the spatial type to use when creating a column for this property.
+        /// </summary>
+        /// <param name="value">The SRID.</param>
+        /// <returns>
+        /// True if the annotation was set; otherwise, false.
+        /// </returns>
+        protected virtual bool SetSpatialType(string value)
+            => Annotations.SetAnnotation(NpgsqlAnnotationNames.SpatialType, value);
+
+        /// <summary>
+        /// Gets or sets the SRID to use when creating a column for this property.
+        /// </summary>
+        public virtual int? Srid
+        {
+            get => (int?)Annotations.Metadata[NpgsqlAnnotationNames.Srid];
+            [param: CanBeNull]
+            set => SetSrid(value);
+        }
+
+        /// <summary>
+        /// Sets the SRID to use when creating a column for this property.
+        /// </summary>
+        /// <param name="value">The SRID.</param>
+        /// <returns>
+        /// True if the annotation was set; otherwise, false.
+        /// </returns>
+        protected virtual bool SetSrid(int? value)
+            => Annotations.SetAnnotation(NpgsqlAnnotationNames.Srid, value);
     }
 }

--- a/src/EFCore.PG/Migrations/Internal/NpgsqlMigrationsAnnotationProvider.cs
+++ b/src/EFCore.PG/Migrations/Internal/NpgsqlMigrationsAnnotationProvider.cs
@@ -33,14 +33,14 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations.Internal
 
         public override IEnumerable<IAnnotation> For(IProperty property)
         {
-            if (property.Npgsql().ValueGenerationStrategy == NpgsqlValueGenerationStrategy.SerialColumn)
-                yield return new Annotation(NpgsqlAnnotationNames.ValueGenerationStrategy, NpgsqlValueGenerationStrategy.SerialColumn);
-            if (property.Npgsql().ValueGenerationStrategy == NpgsqlValueGenerationStrategy.IdentityAlwaysColumn)
-                yield return new Annotation(NpgsqlAnnotationNames.ValueGenerationStrategy, NpgsqlValueGenerationStrategy.IdentityAlwaysColumn);
-            if (property.Npgsql().ValueGenerationStrategy == NpgsqlValueGenerationStrategy.IdentityByDefaultColumn)
-                yield return new Annotation(NpgsqlAnnotationNames.ValueGenerationStrategy, NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
-            if (property.Npgsql().Comment != null)
-                yield return new Annotation(NpgsqlAnnotationNames.Comment, property.Npgsql().Comment);
+            if (property.Npgsql().ValueGenerationStrategy is NpgsqlValueGenerationStrategy npgsqlValueGenerationStrategy)
+                yield return new Annotation(NpgsqlAnnotationNames.ValueGenerationStrategy, npgsqlValueGenerationStrategy);
+            if (property.Npgsql().Comment is string comment)
+                yield return new Annotation(NpgsqlAnnotationNames.Comment, comment);
+            if (property.Npgsql().SpatialType is string spatialType)
+                yield return new Annotation(NpgsqlAnnotationNames.SpatialType, spatialType);
+            if (property.Npgsql().Srid is int srid)
+                yield return new Annotation(NpgsqlAnnotationNames.Srid, srid);
         }
 
         public override IEnumerable<IAnnotation> For(IIndex index)

--- a/test/EFCore.PG.FunctionalTests/Query/SpatialQueryNpgsqlGeographyFixture.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/SpatialQueryNpgsqlGeographyFixture.cs
@@ -3,6 +3,7 @@ using GeoAPI;
 using GeoAPI.Geometries;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.TestModels.SpatialModel;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
 using NetTopologySuite;
@@ -40,7 +41,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             NpgsqlConnection.GlobalTypeMapper.UseNetTopologySuite();
 
             return base.AddServices(serviceCollection)
-                .AddEntityFrameworkNpgsqlNetTopologySuite();
+                       .AddEntityFrameworkNpgsqlNetTopologySuite();
         }
 
         public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
@@ -56,6 +57,24 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             base.OnModelCreating(modelBuilder, context);
 
             modelBuilder.HasPostgresExtension("postgis");
+
+            modelBuilder.Entity<PointEntity>()
+                        .Property(e => e.Point)
+                        .ForNpgsqlHasSpatialType("POINT");
+
+            modelBuilder.Entity<PointEntity>()
+                        .Property(e => e.ConcretePoint)
+                        .ForNpgsqlHasSpatialType("POINT")
+                        .ForNpgsqlHasSrid(4326);
+
+            modelBuilder.Entity<LineStringEntity>()
+                        .Property(e => e.LineString)
+                        .ForNpgsqlHasSpatialType("LINESTRING");
+
+            modelBuilder.Entity<MultiLineStringEntity>()
+                        .Property(e => e.MultiLineString)
+                        .ForNpgsqlHasSpatialType("MULTILINESTRING")
+                        .ForNpgsqlHasSrid(4326);
         }
     }
 }

--- a/test/EFCore.PG.FunctionalTests/Query/SpatialQueryNpgsqlGeometryFixture.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/SpatialQueryNpgsqlGeometryFixture.cs
@@ -1,6 +1,6 @@
-using GeoAPI.Geometries;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.TestModels.SpatialModel;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure;
@@ -18,7 +18,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             NpgsqlConnection.GlobalTypeMapper.UseNetTopologySuite();
 
             return base.AddServices(serviceCollection)
-                .AddEntityFrameworkNpgsqlNetTopologySuite();
+                       .AddEntityFrameworkNpgsqlNetTopologySuite();
         }
 
         public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
@@ -34,6 +34,24 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             base.OnModelCreating(modelBuilder, context);
 
             modelBuilder.HasPostgresExtension("postgis");
+
+            modelBuilder.Entity<PointEntity>()
+                        .Property(e => e.Point)
+                        .ForNpgsqlHasSpatialType("POINT");
+
+            modelBuilder.Entity<PointEntity>()
+                        .Property(e => e.ConcretePoint)
+                        .ForNpgsqlHasSpatialType("POINT")
+                        .ForNpgsqlHasSrid(0);
+
+            modelBuilder.Entity<LineStringEntity>()
+                        .Property(e => e.LineString)
+                        .ForNpgsqlHasSpatialType("LINESTRING");
+
+            modelBuilder.Entity<MultiLineStringEntity>()
+                        .Property(e => e.MultiLineString)
+                        .ForNpgsqlHasSpatialType("MULTILINESTRING")
+                        .ForNpgsqlHasSrid(0);
         }
     }
 }

--- a/test/EFCore.PG.FunctionalTests/SpatialNpgsqlFixture.cs
+++ b/test/EFCore.PG.FunctionalTests/SpatialNpgsqlFixture.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.TestModels.SpatialModel;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure;
@@ -29,6 +30,24 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL
 
             modelBuilder.HasPostgresExtension("postgis")
                         .HasPostgresExtension("uuid-ossp");
+
+            modelBuilder.Entity<PointEntity>()
+                        .Property(e => e.Point)
+                        .ForNpgsqlHasSpatialType("POINT");
+
+            modelBuilder.Entity<PointEntity>()
+                        .Property(e => e.ConcretePoint)
+                        .ForNpgsqlHasSpatialType("POINT")
+                        .ForNpgsqlHasSrid(0);
+
+            modelBuilder.Entity<LineStringEntity>()
+                        .Property(e => e.LineString)
+                        .ForNpgsqlHasSpatialType("LINESTRING");
+
+            modelBuilder.Entity<MultiLineStringEntity>()
+                        .Property(e => e.MultiLineString)
+                        .ForNpgsqlHasSpatialType("MULTILINESTRING")
+                        .ForNpgsqlHasSrid(0);
         }
     }
 }


### PR DESCRIPTION
I was interested in delving deeper into our migrations code, so I picked up #717 to get a better feel for how property annotations interact with migration generation. 

This is an area of the project that I'm less familiar with, but hopefully this isn't too far off the correct implementation. Any advice or feedback would be very much appreciated.

___

This PR follows [similar work in the Sqlite provider](https://github.com/aspnet/EntityFrameworkCore/issues/1100), but is adjusted for PostGIS. Specifically, #717 asked about specifying the SRID of a `geography` or `geometry` column, but (as I understand it) the SRID type modifier can only be set after the spatial type modifier has been set (e.g. `(POINT)` and `(POINT,4326)`, but not `(4326)`).

In general, the goal of this PR is to support the following:

```c#
builder.HasPostgresExtension("postgis");

builder.Entity<SomeTable>()
       .Property(e => e.SomePoint)
       .ForNpgsqlHasSpatialType("POINT")
       .ForNpgsqlHasSrid(4296);

builder.Entity<SomeTable>()
       .Property(e => e.SomeLocation)
       .ForNpgsqlHasSpatialType("POINT");
```

```sql
CREATE TABLE some_table (
    some_point    GEOMETRY  (POINT,4296),
    some_location GEOGRAPHY (POINT)
);
```


___
Closes: #717