### PR TITLE
Normalize annotation access

### DIFF
--- a/src/EFCore.PG/Extensions/NpgsqlMetadataExtensions.cs
+++ b/src/EFCore.PG/Extensions/NpgsqlMetadataExtensions.cs
@@ -46,8 +46,23 @@ namespace Microsoft.EntityFrameworkCore
         public static NpgsqlPropertyAnnotations Npgsql([NotNull] this IMutableProperty property)
             => (NpgsqlPropertyAnnotations)Npgsql((IProperty)property);
 
+        public static NpgsqlAddColumnOperationAnnotations Npgsql([NotNull] this AddColumnOperation operation)
+            => new NpgsqlAddColumnOperationAnnotations(Check.NotNull(operation, nameof(operation)));
+
+        public static NpgsqlAlterColumnOperationAnnotations Npgsql([NotNull] this AlterColumnOperation operation)
+            => new NpgsqlAlterColumnOperationAnnotations(Check.NotNull(operation, nameof(operation)));
+
         public static NpgsqlAlterDatabaseOperationAnnotations Npgsql([NotNull] this AlterDatabaseOperation operation)
             => new NpgsqlAlterDatabaseOperationAnnotations(Check.NotNull(operation, nameof(operation)));
+
+        public static NpgsqlAlterTableOperationAnnotations Npgsql([NotNull] this AlterTableOperation operation)
+            => new NpgsqlAlterTableOperationAnnotations(Check.NotNull(operation, nameof(operation)));
+
+        public static NpgsqlCreateIndexOperationAnnotations Npgsql([NotNull] this CreateIndexOperation operation)
+            => new NpgsqlCreateIndexOperationAnnotations(Check.NotNull(operation, nameof(operation)));
+
+        public static NpgsqlCreateTableOperationAnnotations Npgsql([NotNull] this CreateTableOperation operation)
+            => new NpgsqlCreateTableOperationAnnotations(Check.NotNull(operation, nameof(operation)));
 
         public static NpgsqlDatabaseModelAnnotations Npgsql([NotNull] this DatabaseModel model)
             => new NpgsqlDatabaseModelAnnotations(Check.NotNull(model, nameof(model)));

--- a/src/EFCore.PG/Metadata/NpgsqlAddColumnOperationAnnotations.cs
+++ b/src/EFCore.PG/Metadata/NpgsqlAddColumnOperationAnnotations.cs
@@ -1,0 +1,19 @@
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Migrations.Operations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.Internal;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata
+{
+    /// <summary>
+    /// Provides <see cref="AddColumnOperation"/> annotations specific to Npgsql.
+    /// </summary>
+    public class NpgsqlAddColumnOperationAnnotations : NpgsqlMigrationOperationAnnotations
+    {
+        /// <inheritdoc />
+        public NpgsqlAddColumnOperationAnnotations([NotNull] AddColumnOperation operation) : base(operation) {}
+
+        [CanBeNull]
+        public virtual NpgsqlValueGenerationStrategy? ValueGenerationStrategy
+            => (NpgsqlValueGenerationStrategy?)Metadata[NpgsqlAnnotationNames.ValueGenerationStrategy];
+    }
+}

--- a/src/EFCore.PG/Metadata/NpgsqlAlterColumnOperationAnnotations.cs
+++ b/src/EFCore.PG/Metadata/NpgsqlAlterColumnOperationAnnotations.cs
@@ -1,0 +1,23 @@
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Migrations.Operations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.Internal;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata
+{
+    /// <summary>
+    /// Provides <see cref="AlterColumnOperation"/> annotations specific to Npgsql.
+    /// </summary>
+    public class NpgsqlAlterColumnOperationAnnotations : NpgsqlAlterMigrationOperationAnnotations<AlterColumnOperation>
+    {
+        /// <inheritdoc />
+        public NpgsqlAlterColumnOperationAnnotations([NotNull] AlterColumnOperation operation) : base(operation) {}
+
+        [CanBeNull]
+        public virtual NpgsqlValueGenerationStrategy? ValueGenerationStrategy
+            => (NpgsqlValueGenerationStrategy?)Metadata[NpgsqlAnnotationNames.ValueGenerationStrategy];
+
+        [CanBeNull]
+        public virtual NpgsqlValueGenerationStrategy? OldValueGenerationStrategy
+            => (NpgsqlValueGenerationStrategy?)OldMetadata[NpgsqlAnnotationNames.ValueGenerationStrategy];
+    }
+}

--- a/src/EFCore.PG/Metadata/NpgsqlAlterDatabaseOperationAnnotations.cs
+++ b/src/EFCore.PG/Metadata/NpgsqlAlterDatabaseOperationAnnotations.cs
@@ -1,19 +1,16 @@
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata
 {
     /// <summary>
-    /// Provides relational-specific annotations specific to Npgsql.
+    /// Provides <see cref="AlterDatabaseOperation"/> annotations specific to Npgsql.
     /// </summary>
-    public class NpgsqlAlterDatabaseOperationAnnotations : RelationalAnnotations
+    public class NpgsqlAlterDatabaseOperationAnnotations : NpgsqlAlterMigrationOperationAnnotations<AlterDatabaseOperation>
     {
-        [NotNull] readonly IAnnotatable _oldDatabase;
-
         [NotNull]
         [ItemNotNull]
         public virtual IReadOnlyList<PostgresExtension> PostgresExtensions
@@ -22,7 +19,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata
         [NotNull]
         [ItemNotNull]
         public virtual IReadOnlyList<PostgresExtension> OldPostgresExtensions
-            => PostgresExtension.GetPostgresExtensions(_oldDatabase).ToArray();
+            => PostgresExtension.GetPostgresExtensions(OldMetadata).ToArray();
 
         [NotNull]
         [ItemNotNull]
@@ -32,7 +29,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata
         [NotNull]
         [ItemNotNull]
         public virtual IReadOnlyList<PostgresEnum> OldPostgresEnums
-            => PostgresEnum.GetPostgresEnums(_oldDatabase).ToArray();
+            => PostgresEnum.GetPostgresEnums(OldMetadata).ToArray();
 
         [NotNull]
         [ItemNotNull]
@@ -42,12 +39,10 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata
         [NotNull]
         [ItemNotNull]
         public virtual IReadOnlyList<PostgresRange> OldPostgresRanges
-            => PostgresRange.GetPostgresRanges(_oldDatabase).ToArray();
+            => PostgresRange.GetPostgresRanges(OldMetadata).ToArray();
 
         /// <inheritdoc />
-        public NpgsqlAlterDatabaseOperationAnnotations([NotNull] AlterDatabaseOperation operation)
-            : base(operation)
-            => _oldDatabase = operation.OldDatabase;
+        public NpgsqlAlterDatabaseOperationAnnotations([NotNull] AlterDatabaseOperation operation) : base(operation) {}
 
         [NotNull]
         public virtual PostgresExtension GetOrAddPostgresExtension(
@@ -55,5 +50,12 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata
             [NotNull] string name,
             [CanBeNull] string version)
             => PostgresExtension.GetOrAddPostgresExtension((IMutableAnnotatable)Metadata, schema, name, version);
+
+        [NotNull]
+        public virtual PostgresEnum GetOrAddPostgresEnum(
+            [CanBeNull] string schema,
+            [NotNull] string name,
+            [NotNull] string[] labels)
+            => PostgresEnum.GetOrAddPostgresEnum((IMutableAnnotatable)Metadata, schema, name, labels);
     }
 }

--- a/src/EFCore.PG/Metadata/NpgsqlAlterMigrationOperationAnnotations.cs
+++ b/src/EFCore.PG/Metadata/NpgsqlAlterMigrationOperationAnnotations.cs
@@ -1,0 +1,24 @@
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations.Operations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.Internal;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata
+{
+    /// <summary>
+    /// Provides <see cref="IAlterMigrationOperation"/> annotations specific to Npgsql.
+    /// </summary>
+    public abstract class NpgsqlAlterMigrationOperationAnnotations<T> : NpgsqlMigrationOperationAnnotations where T : MigrationOperation, IAlterMigrationOperation
+    {
+        [NotNull]
+        protected virtual IAnnotatable OldMetadata { get; }
+
+        /// <inheritdoc />
+        protected NpgsqlAlterMigrationOperationAnnotations([NotNull] T operation)
+            : base(operation)
+            => OldMetadata = operation.OldAnnotations;
+
+        [CanBeNull]
+        public virtual string OldComment => (string)OldMetadata[NpgsqlAnnotationNames.Comment];
+    }
+}

--- a/src/EFCore.PG/Metadata/NpgsqlAlterTableOperationAnnotations.cs
+++ b/src/EFCore.PG/Metadata/NpgsqlAlterTableOperationAnnotations.cs
@@ -1,0 +1,14 @@
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Migrations.Operations;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata
+{
+    /// <summary>
+    /// Provides <see cref="AlterTableOperation"/> annotations specific to Npgsql.
+    /// </summary>
+    public class NpgsqlAlterTableOperationAnnotations : NpgsqlAlterMigrationOperationAnnotations<AlterTableOperation>
+    {
+        /// <inheritdoc />
+        public NpgsqlAlterTableOperationAnnotations([NotNull] AlterTableOperation operation) : base(operation) {}
+    }
+}

--- a/src/EFCore.PG/Metadata/NpgsqlCreateIndexOperationAnnotations.cs
+++ b/src/EFCore.PG/Metadata/NpgsqlCreateIndexOperationAnnotations.cs
@@ -1,0 +1,26 @@
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Migrations.Operations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.Internal;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata
+{
+    /// <summary>
+    /// Provides <see cref="CreateIndexOperation"/> annotations specific to Npgsql.
+    /// </summary>
+    public class NpgsqlCreateIndexOperationAnnotations : NpgsqlMigrationOperationAnnotations
+    {
+        /// <inheritdoc />
+        public NpgsqlCreateIndexOperationAnnotations([NotNull] CreateIndexOperation operation) : base(operation) {}
+
+        [CanBeNull]
+        public virtual string Method => (string)Metadata[NpgsqlAnnotationNames.IndexMethod];
+
+        [CanBeNull]
+        [ItemCanBeNull]
+        public virtual string[] Operators => (string[])Metadata[NpgsqlAnnotationNames.IndexOperators];
+
+        [CanBeNull]
+        [ItemCanBeNull]
+        public virtual string[] IncludeProperties => (string[])Metadata[NpgsqlAnnotationNames.IndexInclude];
+    }
+}

--- a/src/EFCore.PG/Metadata/NpgsqlCreateTableOperationAnnotations.cs
+++ b/src/EFCore.PG/Metadata/NpgsqlCreateTableOperationAnnotations.cs
@@ -1,0 +1,18 @@
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Migrations.Operations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.Internal;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata
+{
+    /// <summary>
+    /// Provides <see cref="CreateTableOperation"/> annotations specific to Npgsql.
+    /// </summary>
+    public class NpgsqlCreateTableOperationAnnotations : NpgsqlMigrationOperationAnnotations
+    {
+        /// <inheritdoc />
+        public NpgsqlCreateTableOperationAnnotations([NotNull] CreateTableOperation operation) : base(operation) {}
+
+        [CanBeNull]
+        public virtual string CockroachDbInterleaveInParent => (string)Metadata[CockroachDbAnnotationNames.InterleaveInParent];
+    }
+}

--- a/src/EFCore.PG/Metadata/NpgsqlDatabaseModelAnnotations.cs
+++ b/src/EFCore.PG/Metadata/NpgsqlDatabaseModelAnnotations.cs
@@ -32,5 +32,12 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata
             [NotNull] string name,
             [CanBeNull] string version)
             => PostgresExtension.GetOrAddPostgresExtension((IMutableAnnotatable)Metadata, schema, name, version);
+
+        [NotNull]
+        public virtual PostgresEnum GetOrAddPostgresEnum(
+            [CanBeNull] string schema,
+            [NotNull] string name,
+            [NotNull] string[] labels)
+            => PostgresEnum.GetOrAddPostgresEnum((IMutableAnnotatable)Metadata, schema, name, labels);
     }
 }

--- a/src/EFCore.PG/Metadata/NpgsqlMigrationOperationAnnotations.cs
+++ b/src/EFCore.PG/Metadata/NpgsqlMigrationOperationAnnotations.cs
@@ -1,0 +1,19 @@
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations.Operations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.Internal;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata
+{
+    /// <summary>
+    /// Provides <see cref="MigrationOperation"/> annotations specific to Npgsql.
+    /// </summary>
+    public class NpgsqlMigrationOperationAnnotations : RelationalAnnotations
+    {
+        /// <inheritdoc />
+        protected NpgsqlMigrationOperationAnnotations([NotNull] MigrationOperation operation) : base(operation) {}
+
+        [CanBeNull]
+        public virtual string Comment => (string)Metadata[NpgsqlAnnotationNames.Comment];
+    }
+}

--- a/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
@@ -85,7 +85,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations
             base.Generate(operation, model, builder, false);
 
             // CockroachDB "interleave in parent" (https://www.cockroachlabs.com/docs/stable/interleave-in-parent.html)
-            if (operation[CockroachDbAnnotationNames.InterleaveInParent] is string)
+            if (operation.Npgsql().CockroachDbInterleaveInParent != null)
             {
                 var interleaveInParent = new CockroachDbInterleaveInParent(operation);
                 var parentTableSchema = interleaveInParent.ParentTableSchema;
@@ -112,7 +112,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations
             }
 
             // Comment on the table
-            if (operation[NpgsqlAnnotationNames.Comment] is string comment && comment.Length > 0)
+            if (operation.Npgsql().Comment is string comment && comment.Length > 0)
             {
                 builder.AppendLine(';');
 
@@ -126,9 +126,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations
             }
 
             // Comments on the columns
-            foreach (var columnOp in operation.Columns.Where(c => c[NpgsqlAnnotationNames.Comment] != null))
+            foreach (var columnOp in operation.Columns.Where(c => c.Npgsql().Comment != null))
             {
-                var columnComment = columnOp[NpgsqlAnnotationNames.Comment];
+                var columnComment = columnOp.Npgsql().Comment;
                 builder.AppendLine(';');
 
                 var stringTypeMapping = Dependencies.TypeMappingSource.GetMapping(typeof(string));
@@ -198,8 +198,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations
             }
 
             // Comment
-            var oldComment = operation.OldTable[NpgsqlAnnotationNames.Comment] as string;
-            var newComment = operation[NpgsqlAnnotationNames.Comment] as string;
+            var oldComment = operation.Npgsql().OldComment;
+            var newComment = operation.Npgsql().Comment;
 
             if (oldComment != newComment)
             {
@@ -244,7 +244,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations
 
             base.Generate(operation, model, builder, terminate: false);
 
-            if (operation[NpgsqlAnnotationNames.Comment] is string comment && comment.Length > 0)
+            if (operation.Npgsql().Comment is string comment && comment.Length > 0)
             {
                 builder.AppendLine(';');
 
@@ -297,8 +297,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations
 
             CheckForOldValueGenerationAnnotation(operation);
 
-            var oldStrategy = operation.OldColumn[NpgsqlAnnotationNames.ValueGenerationStrategy] as NpgsqlValueGenerationStrategy?;
-            var newStrategy = operation[NpgsqlAnnotationNames.ValueGenerationStrategy] as NpgsqlValueGenerationStrategy?;
+            var oldStrategy = operation.Npgsql().OldValueGenerationStrategy;
+            var newStrategy = operation.Npgsql().ValueGenerationStrategy;
 
             if (oldStrategy != newStrategy)
             {
@@ -427,8 +427,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations
             }
 
             // Comment
-            var oldComment = operation.OldColumn[NpgsqlAnnotationNames.Comment] as string;
-            var newComment = operation[NpgsqlAnnotationNames.Comment] as string;
+            var oldComment = operation.Npgsql().OldComment;
+            var newComment = operation.Npgsql().Comment;
 
             if (oldComment != newComment)
             {
@@ -529,14 +529,14 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations
                 .Append(" ON ")
                 .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Table, operation.Schema));
 
-            if (operation[NpgsqlAnnotationNames.IndexMethod] is string method && method.Length > 0)
+            if (operation.Npgsql().Method is string method && method.Length > 0)
             {
                 builder
                     .Append(" USING ")
                     .Append(method);
             }
 
-            var operators = operation[NpgsqlAnnotationNames.IndexOperators] as string[];
+            var operators = operation.Npgsql().Operators;
 
             builder
                 .Append(" (")
@@ -552,7 +552,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations
 
         protected override void IndexOptions(CreateIndexOperation operation, IModel model, MigrationCommandListBuilder builder)
         {
-            if (operation[NpgsqlAnnotationNames.IndexInclude] is string[] includeProperties && includeProperties.Length > 0)
+            if (operation.Npgsql().IncludeProperties is string[] includeProperties && includeProperties.Length > 0)
             {
                 builder
                     .Append(" INCLUDE (")

--- a/src/EFCore.PG/Scaffolding/Internal/NpgsqlDatabaseModelFactory.cs
+++ b/src/EFCore.PG/Scaffolding/Internal/NpgsqlDatabaseModelFactory.cs
@@ -849,7 +849,7 @@ GROUP BY
                     if (schema == "public")
                         schema = null;
 
-                    PostgresEnum.GetOrAddPostgresEnum(databaseModel, schema, name, labels);
+                    databaseModel.Npgsql().GetOrAddPostgresEnum(schema, name, labels);
                     enums.Add(name);
                 }
 

--- a/test/EFCore.PG.FunctionalTests/NpgsqlMigrationSqlGeneratorTest.cs
+++ b/test/EFCore.PG.FunctionalTests/NpgsqlMigrationSqlGeneratorTest.cs
@@ -744,7 +744,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL
         public void CreatePostgresEnum()
         {
             var op = new AlterDatabaseOperation();
-            PostgresEnum.GetOrAddPostgresEnum(op, "public", "my_enum", new[] { "value1", "value2" });
+            op.Npgsql().GetOrAddPostgresEnum("public", "my_enum", new[] { "value1", "value2" });
             Generate(op);
 
             Assert.Equal(@"CREATE TYPE public.my_enum AS ENUM ('value1', 'value2');" + EOL, Sql);
@@ -754,7 +754,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL
         public void CreatePostgresEnumWithSchema()
         {
             var op = new AlterDatabaseOperation();
-            PostgresEnum.GetOrAddPostgresEnum(op, "some_schema", "my_enum", new[] { "value1", "value2" });
+            op.Npgsql().GetOrAddPostgresEnum("some_schema", "my_enum", new[] { "value1", "value2" });
             Generate(op);
 
             Assert.Equal(


### PR DESCRIPTION
~~Small refactor to normalize annotation access patterns ahead of #730 and #736.~~

Provides additional annotation wrappers for migration operations that need to access Npgsql-specific annotations.