### PR TITLE
Bump our version to 3.0, clean up versions

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,6 @@
 ﻿<Project>
   <PropertyGroup Label="Package Versions">
+    <VersionPrefix>3.0.0</VersionPrefix>
     <NpgsqlVersion>4.0.4</NpgsqlVersion>
     <EFCoreVersion>2.2.0</EFCoreVersion>
     <MicrosoftExtensionsVersion>$(EFCoreVersion)</MicrosoftExtensionsVersion>

--- a/src/EFCore.PG.NTS/EFCore.PG.NTS.csproj
+++ b/src/EFCore.PG.NTS/EFCore.PG.NTS.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <VersionPrefix>$(EFCoreVersion)</VersionPrefix>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyName>Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite</AssemblyName>
     <RootNamespace>Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite</RootNamespace>

--- a/src/EFCore.PG.NodaTime/EFCore.PG.NodaTime.csproj
+++ b/src/EFCore.PG.NodaTime/EFCore.PG.NodaTime.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <VersionPrefix>$(EFCoreVersion)</VersionPrefix>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyName>Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime</AssemblyName>
     <RootNamespace>Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime</RootNamespace>

--- a/src/EFCore.PG/EFCore.PG.csproj
+++ b/src/EFCore.PG/EFCore.PG.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <VersionPrefix>$(EFCoreVersion)</VersionPrefix>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyName>Npgsql.EntityFrameworkCore.PostgreSQL</AssemblyName>
     <RootNamespace>Npgsql.EntityFrameworkCore.PostgreSQL</RootNamespace>


### PR DESCRIPTION
Our own version is now separate from the EF Core version we depend on. This is important since during regular we need to have version 3.0.0 (the CI suffix will later be tacked on at the build server), while we depend on something like 3.0.0-preview.18572.1.

Note that still depend on EF Core 2.2, porting to 3.0.0-preview1 is ongoing in a separate branch.