### PR TITLE
Add CODEOWNERS files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @roji @austindrenski @YohDeadfall


### PR DESCRIPTION
This adds [a GitHub CODEOWNERS file](https://help.github.com/articles/about-codeowners/), which is supposed to automatically request reviews on every pull requested submitted to the repo.

Assuming you guys are interested in being involved in every change, this will make it easier to manage the process. I propose that by default we continue as we have up to now, i.e. wait for all three of us to review before merging (aside from trivial changes). If anyone sees that they have no time (or interest) in reviewing a particular PR, we can just leave a comment saying that, and merge without that person's approval. Does that sound like a good process?

PS I can also add the same on the http://github.com/npgsql/npgsql/ repo, let me know if that's OK for you.

