### PR TITLE
Changes for 3.0.0-preview1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup Label="Package Versions">
     <VersionPrefix>3.0.0</VersionPrefix>
     <NpgsqlVersion>4.0.4</NpgsqlVersion>
-    <EFCoreVersion>2.2.0</EFCoreVersion>
+    <EFCoreVersion>3.0.0-preview.18572.1</EFCoreVersion>
     <MicrosoftExtensionsVersion>$(EFCoreVersion)</MicrosoftExtensionsVersion>
   </PropertyGroup>
 </Project>

--- a/src/EFCore.PG/Extensions/NpgsqlServiceCollectionExtensions.cs
+++ b/src/EFCore.PG/Extensions/NpgsqlServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors;
+using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Query.Sql;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Update;
@@ -23,7 +24,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Update.Internal;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Utilities;
 using Npgsql.EntityFrameworkCore.PostgreSQL.ValueGeneration.Internal;
-using Remotion.Linq.Parsing.ExpressionVisitors.TreeEvaluation;
+using ReLinq = Remotion.Linq.Parsing.ExpressionVisitors.TreeEvaluation;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
@@ -92,6 +93,7 @@ namespace Microsoft.Extensions.DependencyInjection
                     .TryAdd<IQuerySqlGeneratorFactory, NpgsqlQuerySqlGeneratorFactory>()
                     .TryAdd<ISqlTranslatingExpressionVisitorFactory, NpgsqlSqlTranslatingExpressionVisitorFactory>()
                     .TryAdd<ISingletonOptions, INpgsqlOptions>(p => p.GetService<INpgsqlOptions>())
+                    .TryAdd<ReLinq.IEvaluatableExpressionFilter, ReLinqNpgsqlCompositeEvaluatableExpressionFilter>()
                     .TryAdd<IEvaluatableExpressionFilter, NpgsqlCompositeEvaluatableExpressionFilter>()
                     .TryAddProviderSpecificServices(
                         b => b

--- a/src/EFCore.PG/Query/EvaluatableExpressionFilters/Internal/NpgsqlFullTextSearchEvaluatableExpressionFilter.cs
+++ b/src/EFCore.PG/Query/EvaluatableExpressionFilters/Internal/NpgsqlFullTextSearchEvaluatableExpressionFilter.cs
@@ -2,8 +2,8 @@
 using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Query.Internal;
 using NpgsqlTypes;
-using Remotion.Linq.Parsing.ExpressionVisitors.TreeEvaluation;
 
 // TODO: https://github.com/aspnet/EntityFrameworkCore/issues/11466 may provide a better way for implementing
 // this (we're currently replacing an internal service
@@ -12,7 +12,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.EvaluatableExpressionFilte
     /// <summary>
     /// Represents an Npgsql-specific filter for full-text search to identify expressions that are evaluatable.
     /// </summary>
-    public class NpgsqlFullTextSearchEvaluatableExpressionFilter : IEvaluatableExpressionFilter
+    public class NpgsqlFullTextSearchEvaluatableExpressionFilter : EvaluatableExpressionFilterBase
     {
         /// <summary>
         /// The static method info for <see cref="NpgsqlTsQuery.Parse(string)"/>.
@@ -27,43 +27,12 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.EvaluatableExpressionFilte
             typeof(NpgsqlTsVector).GetRuntimeMethod(nameof(NpgsqlTsVector.Parse), new[] { typeof(string) });
 
         /// <inheritdoc />
-        public bool IsEvaluatableMethodCall(MethodCallExpression node)
-            => node.Method != TsQueryParse &&
-               node.Method != TsVectorParse &&
-               node.Method.DeclaringType != typeof(NpgsqlFullTextSearchDbFunctionsExtensions) &&
-               node.Method.DeclaringType != typeof(NpgsqlFullTextSearchLinqExtensions);
-
-        #region unused interface methods
-
-        bool IEvaluatableExpressionFilter.IsEvaluatableBinary(BinaryExpression node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableConditional(ConditionalExpression node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableConstant(ConstantExpression node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableElementInit(ElementInit node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableInvocation(InvocationExpression node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableLambda(LambdaExpression node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableListInit(ListInitExpression node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableMember(MemberExpression node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableMemberAssignment(MemberAssignment node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableMemberInit(MemberInitExpression node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableMemberListBinding(MemberListBinding node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableMemberMemberBinding(MemberMemberBinding node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableNew(NewExpression node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableNewArray(NewArrayExpression node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableTypeBinary(TypeBinaryExpression node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableUnary(UnaryExpression node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableBlock(BlockExpression node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableCatchBlock(CatchBlock node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableDebugInfo(DebugInfoExpression node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableDefault(DefaultExpression node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableGoto(GotoExpression node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableIndex(IndexExpression node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableLabel(LabelExpression node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableLabelTarget(LabelTarget node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableLoop(LoopExpression node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableSwitch(SwitchExpression node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableSwitchCase(SwitchCase node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableTry(TryExpression node) => true;
-
-        #endregion
+        public override bool IsEvaluatableExpression(Expression expression)
+            => !(expression is MethodCallExpression e && (
+                   e.Method == TsQueryParse ||
+                   e.Method == TsVectorParse ||
+                   e.Method.DeclaringType == typeof(NpgsqlFullTextSearchDbFunctionsExtensions) ||
+                   e.Method.DeclaringType == typeof(NpgsqlFullTextSearchLinqExtensions)
+               ));
     }
 }

--- a/src/EFCore.PG/Query/EvaluatableExpressionFilters/Internal/NpgsqlFullTextSearchEvaluatableExpressionFilter.cs
+++ b/src/EFCore.PG/Query/EvaluatableExpressionFilters/Internal/NpgsqlFullTextSearchEvaluatableExpressionFilter.cs
@@ -29,8 +29,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.EvaluatableExpressionFilte
         /// <inheritdoc />
         public override bool IsEvaluatableExpression(Expression expression)
             => !(expression is MethodCallExpression e && (
-                   e.Method == TsQueryParse ||
-                   e.Method == TsVectorParse ||
+                   e.Method == TsQueryParse || e.Method == TsVectorParse ||
                    e.Method.DeclaringType == typeof(NpgsqlFullTextSearchDbFunctionsExtensions) ||
                    e.Method.DeclaringType == typeof(NpgsqlFullTextSearchLinqExtensions)
                ));

--- a/src/EFCore.PG/Query/EvaluatableExpressionFilters/Internal/NpgsqlNodaTimeEvaluatableExpressionFilter.cs
+++ b/src/EFCore.PG/Query/EvaluatableExpressionFilters/Internal/NpgsqlNodaTimeEvaluatableExpressionFilter.cs
@@ -24,56 +24,22 @@
 #endregion
 
 using System.Linq.Expressions;
-using System.Reflection;
-using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore;
-using NpgsqlTypes;
-using Remotion.Linq.Parsing.ExpressionVisitors.TreeEvaluation;
+using Microsoft.EntityFrameworkCore.Query.Internal;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.EvaluatableExpressionFilters.Internal
 {
     // TODO: This is a hack until https://github.com/aspnet/EntityFrameworkCore/issues/13454 is done
-    public class NpgsqlNodaTimeEvaluatableExpressionFilter : IEvaluatableExpressionFilter
+    public class NpgsqlNodaTimeEvaluatableExpressionFilter : EvaluatableExpressionFilterBase
     {
         /// <inheritdoc />
-        public bool IsEvaluatableMethodCall(MethodCallExpression node)
-            => node.Method.DeclaringType?.FullName != "NodaTime.SystemClock" ||
-               node.Method.Name != "GetCurrentInstant";
-
-        bool IEvaluatableExpressionFilter.IsEvaluatableMember(MemberExpression node)
-            => node.Member.DeclaringType?.FullName != "NodaTime.SystemClock" ||
-               node.Member.Name != "Instance";
-
-        #region unused interface methods
-
-        bool IEvaluatableExpressionFilter.IsEvaluatableBinary(BinaryExpression node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableConditional(ConditionalExpression node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableConstant(ConstantExpression node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableElementInit(ElementInit node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableInvocation(InvocationExpression node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableLambda(LambdaExpression node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableListInit(ListInitExpression node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableMemberAssignment(MemberAssignment node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableMemberInit(MemberInitExpression node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableMemberListBinding(MemberListBinding node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableMemberMemberBinding(MemberMemberBinding node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableNew(NewExpression node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableNewArray(NewArrayExpression node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableTypeBinary(TypeBinaryExpression node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableUnary(UnaryExpression node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableBlock(BlockExpression node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableCatchBlock(CatchBlock node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableDebugInfo(DebugInfoExpression node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableDefault(DefaultExpression node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableGoto(GotoExpression node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableIndex(IndexExpression node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableLabel(LabelExpression node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableLabelTarget(LabelTarget node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableLoop(LoopExpression node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableSwitch(SwitchExpression node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableSwitchCase(SwitchCase node) => true;
-        bool IEvaluatableExpressionFilter.IsEvaluatableTry(TryExpression node) => true;
-
-        #endregion
+        public override bool IsEvaluatableExpression(Expression expression)
+            => !(
+                (expression is MethodCallExpression methodExpr &&
+                methodExpr.Method.DeclaringType?.FullName == "NodaTime.SystemClock" &&
+                methodExpr.Method.Name == "GetCurrentInstant")
+                ||
+                (expression is MemberExpression memberExpr &&
+                memberExpr.Member.DeclaringType?.FullName == "NodaTime.SystemClock" &&
+                memberExpr.Member.Name == "Instance"));
     }
 }

--- a/src/EFCore.PG/Query/EvaluatableExpressionFilters/Internal/ReLinqNpgsqlCompositeEvaluatableExpressionFilter.cs
+++ b/src/EFCore.PG/Query/EvaluatableExpressionFilters/Internal/ReLinqNpgsqlCompositeEvaluatableExpressionFilter.cs
@@ -11,7 +11,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.EvaluatableExpressionFilte
     /// <summary>
     /// A composite evaluatable expression filter that dispatches to multiple specialized filters specific to Npgsql.
     /// </summary>
-    public class NpgsqlCompositeEvaluatableExpressionFilter : RelationalEvaluatableExpressionFilter
+    public class ReLinqNpgsqlCompositeEvaluatableExpressionFilter : ReLinqRelationalEvaluatableExpressionFilter
     {
         /// <summary>
         /// The collection of registered evaluatable expression filters.
@@ -24,11 +24,16 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.EvaluatableExpressionFilte
             };
 
         /// <inheritdoc />
-        public NpgsqlCompositeEvaluatableExpressionFilter([NotNull] IModel model) : base(model) {}
+        public ReLinqNpgsqlCompositeEvaluatableExpressionFilter([NotNull] IModel model) : base(model) {}
 
         /// <inheritdoc />
-        public override bool IsEvaluatableExpression(Expression expression)
-            => _filters.All(x => x.IsEvaluatableExpression(expression)) && base.IsEvaluatableExpression(expression);
+        public override bool IsEvaluatableMember(MemberExpression expression)
+            => _filters.All(x => x.IsEvaluatableExpression(expression)) && base.IsEvaluatableMember(expression);
+
+        /// <inheritdoc />
+        public override bool IsEvaluatableMethodCall(MethodCallExpression expression)
+            => _filters.All(x => x.IsEvaluatableExpression(expression)) && base.IsEvaluatableMethodCall(expression);
+
 
         /// <summary>
         /// Adds additional dispatches to the filters list.

--- a/src/EFCore.PG/Query/EvaluatableExpressionFilters/Internal/ReLinqNpgsqlCompositeEvaluatableExpressionFilter.cs
+++ b/src/EFCore.PG/Query/EvaluatableExpressionFilters/Internal/ReLinqNpgsqlCompositeEvaluatableExpressionFilter.cs
@@ -34,7 +34,6 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.EvaluatableExpressionFilte
         public override bool IsEvaluatableMethodCall(MethodCallExpression expression)
             => _filters.All(x => x.IsEvaluatableExpression(expression)) && base.IsEvaluatableMethodCall(expression);
 
-
         /// <summary>
         /// Adds additional dispatches to the filters list.
         /// </summary>

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlDateTimeMemberTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlDateTimeMemberTranslator.cs
@@ -133,7 +133,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Inte
             if (floor)
                 result = new SqlFunctionExpression("FLOOR", typeof(double), new[] { result });
 
-            return new ExplicitCastExpression(result, typeof(int));
+            return new ExplicitStoreTypeCastExpression(result, typeof(int), "int");
         }
     }
 }

--- a/src/EFCore.PG/Query/Sql/Internal/NpgsqlQuerySqlGeneratorFactory.cs
+++ b/src/EFCore.PG/Query/Sql/Internal/NpgsqlQuerySqlGeneratorFactory.cs
@@ -28,6 +28,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.Sql.Internal
             => new NpgsqlQuerySqlGenerator(
                 Dependencies,
                 Check.NotNull(selectExpression, nameof(selectExpression)),
-                _npgsqlOptions.ReverseNullOrderingEnabled);
+                _npgsqlOptions.ReverseNullOrderingEnabled,
+                _npgsqlOptions.PostgresVersion);
     }
 }

--- a/test/EFCore.PG.FunctionalTests/BuiltInDataTypesNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/BuiltInDataTypesNpgsqlTest.cs
@@ -63,7 +63,7 @@ WHERE e.""TimeSpanAsTime"" = TIME '00:01:02'",
 
                 Assert.Equal(0, results.Count);
                 Assert.Equal(
-                    @"@__timeSpan_0='02:01:00' (DbType = Object)
+                    @"@__timeSpan_0='02:01:00' (Nullable = true) (DbType = Object)
 
 SELECT e.""Int""
 FROM ""MappedNullableDataTypes"" AS e
@@ -108,7 +108,8 @@ WHERE e.""TimeSpanAsTime"" = @__timeSpan_0",
 
                         StringAsText = "Gumball Rules!",
                         StringAsVarchar = "Gumball Rules OK",
-                        CharAsChar1 = 'f',
+                        // TODO: enable here (and above) after https://github.com/aspnet/EntityFrameworkCore/issues/14159 is fixed
+                        // CharAsChar1 = 'f',
                         CharAsText = 'g',
                         CharAsVarchar = 'h',
                         BytesAsBytea = new byte[] { 86 },
@@ -212,8 +213,9 @@ WHERE e.""TimeSpanAsTime"" = @__timeSpan_0",
                 var param21 = "Gumball Rules OK";
                 Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.StringAsVarchar == param21));
 
-                var param21a = 'f';
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.CharAsChar1 == param21a));
+                // TODO: enable here (and above) after https://github.com/aspnet/EntityFrameworkCore/issues/14159 is fixed
+                // var param21a = 'f';
+                // Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.CharAsChar1 == param21a));
 
                 var param21b = 'g';
                 Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.CharAsText == param21b));
@@ -366,8 +368,9 @@ WHERE e.""TimeSpanAsTime"" = @__timeSpan_0",
                 string param21 = null;
                 Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.StringAsVarchar == param21));
 
-                char? param21a = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.CharAsChar1 == param21a));
+                // TODO: enable here (and above) after https://github.com/aspnet/EntityFrameworkCore/issues/14159 is fixed
+                // char? param21a = null;
+                // Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.CharAsChar1 == param21a));
 
                 char? param21b = null;
                 Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.CharAsText == param21b));
@@ -448,46 +451,45 @@ WHERE e.""TimeSpanAsTime"" = @__timeSpan_0",
 @p1='True'
 @p2='80'
 @p3='0x56' (Nullable = false)
-@p4='f' (DbType = String)
-@p5='g' (Nullable = false)
-@p6='h' (Nullable = false)
-@p7='2015-01-02T00:00:00' (DbType = Date)
-@p8='2015-01-02T10:11:12' (DbType = DateTime)
-@p9='2016-01-02T11:11:12' (DbType = DateTimeOffset)
-@p10='0001-01-01T12:00:00.0000000+02:00' (DbType = Object)
-@p11='101.7'
-@p12='81.1'
-@p13='103.9'
-@p14='System.Collections.Generic.Dictionary`2[System.String,System.String]' (Nullable = false) (DbType = Object)
-@p15='85.5'
+@p4='g' (Nullable = false)
+@p5='h' (Nullable = false)
+@p6='2015-01-02T00:00:00' (DbType = Date)
+@p7='2015-01-02T10:11:12' (DbType = DateTime)
+@p8='2016-01-02T11:11:12' (DbType = DateTimeOffset)
+@p9='0001-01-01T12:00:00.0000000+02:00' (DbType = Object)
+@p10='101.7'
+@p11='81.1'
+@p12='103.9'
+@p13='System.Collections.Generic.Dictionary`2[System.String,System.String]' (Nullable = false) (DbType = Object)
+@p14='85.5'
+@p15='Value4' (Nullable = false)
 @p16='Value4' (Nullable = false)
-@p17='Value4' (Nullable = false)
-@p18='84.4'
-@p19='a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'
-@p20='System.Int32[]' (Nullable = false) (DbType = Object)
-@p21='78'
-@p22='Sad' (DbType = Object)
-@p23='(5.2,3.3)' (DbType = Object)
-@p24='[4,8)' (DbType = Object)
-@p25='System.Net.NetworkInformation.PhysicalAddress[]' (Nullable = false) (DbType = Object)
-@p26='08002B010203' (Nullable = false) (DbType = Object)
-@p27='2'
-@p28='12724' (DbType = Object)
-@p29=''a' & 'b'' (Nullable = false) (DbType = Object)
-@p30=''a' 'b'' (Nullable = false) (DbType = Object)
-@p31='79'
-@p32='{""a"": ""b""}' (Nullable = false)
-@p33='{""a"": ""b""}' (Nullable = false) (DbType = Object)
-@p34='Gumball Rules!' (Nullable = false)
-@p35='Gumball Rules OK' (Nullable = false)
+@p17='84.4'
+@p18='a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'
+@p19='System.Int32[]' (Nullable = false) (DbType = Object)
+@p20='78'
+@p21='Sad' (DbType = Object)
+@p22='(5.2,3.3)' (DbType = Object)
+@p23='[4,8)' (DbType = Object)
+@p24='System.Net.NetworkInformation.PhysicalAddress[]' (Nullable = false) (DbType = Object)
+@p25='08002B010203' (Nullable = false) (DbType = Object)
+@p26='2'
+@p27='12724' (DbType = Object)
+@p28=''a' & 'b'' (Nullable = false) (DbType = Object)
+@p29=''a' 'b'' (Nullable = false) (DbType = Object)
+@p30='79'
+@p31='{""a"": ""b""}' (Nullable = false)
+@p32='{""a"": ""b""}' (Nullable = false) (DbType = Object)
+@p33='Gumball Rules!' (Nullable = false)
+@p34='Gumball Rules OK' (Nullable = false)
+@p35='11:15:12' (DbType = Object)
 @p36='11:15:12' (DbType = Object)
-@p37='11:15:12' (DbType = Object)
-@p38='65535'
-@p39='-1'
-@p40='4294967295'
-@p41='-1'
-@p42='2147483648' (DbType = Object)
-@p43='-1'",
+@p37='65535'
+@p38='-1'
+@p39='4294967295'
+@p40='-1'
+@p41='2147483648' (DbType = Object)
+@p42='-1'",
                     parameters,
                     ignoreLineEndingDifferences: true);
         }
@@ -524,7 +526,8 @@ WHERE e.""TimeSpanAsTime"" = @__timeSpan_0",
 
             Assert.Equal("Gumball Rules!", entity.StringAsText);
             Assert.Equal("Gumball Rules OK", entity.StringAsVarchar);
-            Assert.Equal('f', entity.CharAsChar1);
+            // TODO: enable here (and above) after https://github.com/aspnet/EntityFrameworkCore/issues/14159 is fixed
+            // Assert.Equal('f', entity.CharAsChar1);
             Assert.Equal('g', entity.CharAsText);
             Assert.Equal('h', entity.CharAsVarchar);
             Assert.Equal(new byte[] { 86 }, entity.BytesAsBytea);
@@ -581,7 +584,8 @@ WHERE e.""TimeSpanAsTime"" = @__timeSpan_0",
 
                 StringAsText = "Gumball Rules!",
                 StringAsVarchar = "Gumball Rules OK",
-                CharAsChar1 = 'f',
+                // TODO: enable here (and above) after https://github.com/aspnet/EntityFrameworkCore/issues/14159 is fixed
+                // CharAsChar1 = 'f',
                 CharAsText = 'g',
                 CharAsVarchar = 'h',
                 BytesAsBytea = new byte[] { 86 },
@@ -656,7 +660,8 @@ WHERE e.""TimeSpanAsTime"" = @__timeSpan_0",
 
             Assert.Null(entity.StringAsText);
             Assert.Null(entity.StringAsVarchar);
-            Assert.Null(entity.CharAsChar1);
+            // TODO: enable here (and above) after https://github.com/aspnet/EntityFrameworkCore/issues/14159 is fixed
+            // Assert.Null(entity.CharAsChar1);
             Assert.Null(entity.CharAsText);
             Assert.Null(entity.CharAsVarchar);
             Assert.Null(entity.BytesAsBytea);
@@ -685,6 +690,12 @@ WHERE e.""TimeSpanAsTime"" = @__timeSpan_0",
             Assert.Null(entity.Mood);
         }
 
+        [Fact(Skip="https://github.com/aspnet/EntityFrameworkCore/issues/14159")]
+        public override void Can_query_using_any_data_type_nullable_shadow() {}
+
+        [Fact(Skip="https://github.com/aspnet/EntityFrameworkCore/issues/14159")]
+        public override void Can_query_using_any_data_type_shadow() {}
+
         string Sql => Fixture.TestSqlLoggerFactory.Sql;
 
         static readonly string EOL = Environment.NewLine;
@@ -700,6 +711,10 @@ WHERE e.""TimeSpanAsTime"" = @__timeSpan_0",
             public override bool SupportsLargeStringComparisons => true;
 
             protected override ITestStoreFactory TestStoreFactory => NpgsqlTestStoreFactory.Instance;
+
+            protected override bool ShouldLogCategory(string logCategory)
+                => logCategory == DbLoggerCategory.Query.Name;
+
             public TestSqlLoggerFactory TestSqlLoggerFactory => (TestSqlLoggerFactory)ServiceProvider.GetRequiredService<ILoggerFactory>();
 
             protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
@@ -879,8 +894,9 @@ WHERE e.""TimeSpanAsTime"" = @__timeSpan_0",
             [Column(TypeName = "varchar")]
             public string StringAsVarchar { get; set; }
 
-            [Column(TypeName = "char(1)")]
-            public char? CharAsChar1 { get; set; }
+            // TODO: enable here (and above) after https://github.com/aspnet/EntityFrameworkCore/issues/14159 is fixed
+            // [Column(TypeName = "char(1)")]
+            // public char? CharAsChar1 { get; set; }
 
             [Column(TypeName = "text")]
             public char? CharAsText { get; set; }
@@ -1056,8 +1072,9 @@ WHERE e.""TimeSpanAsTime"" = @__timeSpan_0",
             [Column(TypeName = "varchar")]
             public string StringAsVarchar { get; set; }
 
-            [Column(TypeName = "char(1)")]
-            public char? CharAsChar1 { get; set; }
+            // TODO: enable here (and above) after https://github.com/aspnet/EntityFrameworkCore/issues/14159 is fixed
+            // [Column(TypeName = "char(1)")]
+            // public char? CharAsChar1 { get; set; }
 
             [Column(TypeName = "text")]
             public char? CharAsText { get; set; }

--- a/test/EFCore.PG.FunctionalTests/CustomConvertersNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/CustomConvertersNpgsqlTest.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Npgsql.EntityFrameworkCore.PostgreSQL.TestUtilities;
+using Xunit;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL
 {
@@ -15,6 +16,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL
 
         // Disabled: PostgreSQL is case-sensitive
         public override void Can_insert_and_read_back_with_case_insensitive_string_key() {}
+
+        [Fact(Skip="https://github.com/aspnet/EntityFrameworkCore/issues/14159")]
+        public override void Can_query_using_any_data_type_nullable_shadow() {}
 
         public class CustomConvertersNpgsqlFixture : CustomConvertersFixtureBase
         {

--- a/test/EFCore.PG.FunctionalTests/Query/NetworkQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/NetworkQueryNpgsqlTest.cs
@@ -80,7 +80,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
                            .Where(x => x.Inet.Equals(IPAddress.Parse(x.TextInet)))
                            .ToArray();
 
-                AssertContainsSql("WHERE x.\"Inet\" = CAST(x.\"TextInet\" AS inet)");
+                AssertContainsSql("WHERE (x.\"Inet\" = CAST(x.\"TextInet\" AS inet))");
             }
         }
 
@@ -97,7 +97,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
                            .Where(x => x.Macaddr.Equals(PhysicalAddress.Parse(x.TextMacaddr)))
                            .ToArray();
 
-                AssertContainsSql("WHERE x.\"Macaddr\" = CAST(x.\"TextMacaddr\" AS macaddr)");
+                AssertContainsSql("WHERE (x.\"Macaddr\" = CAST(x.\"TextMacaddr\" AS macaddr))");
             }
         }
 
@@ -114,7 +114,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
                            .Where(x => x.Inet.Equals(IPAddress.Parse("127.0.0.1")))
                            .ToArray();
 
-                AssertContainsSql("WHERE x.\"Inet\" = @__Parse_0");
+                AssertContainsSql("WHERE x.\"Inet\" = INET '127.0.0.1'");
             }
         }
 
@@ -131,7 +131,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
                            .Where(x => x.Macaddr.Equals(PhysicalAddress.Parse("12-34-56-00-00-00")))
                            .ToArray();
 
-                AssertContainsSql("WHERE x.\"Macaddr\" = @__Parse_0");
+                AssertContainsSql("WHERE x.\"Macaddr\" = MACADDR '123456000000'");
             }
         }
 

--- a/test/EFCore.PG.FunctionalTests/Query/RangeQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/RangeQueryNpgsqlTest.cs
@@ -498,7 +498,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             using (var context = Fixture.CreateContext())
             {
                 var e = context.RangeTestEntities.Single(x => x.SchemaRange == NpgsqlRange<double>.Parse("(0,10)"));
-                AssertContainsSql("WHERE x.\"SchemaRange\" = @__Parse_0");
+                AssertContainsSql("WHERE x.\"SchemaRange\" = '(0,10)'::test.\"Schema_Range\"");
                 Assert.Equal(e.SchemaRange.LowerBound, 0);
                 Assert.Equal(e.SchemaRange.UpperBound, 10);
             }

--- a/test/EFCore.PG.FunctionalTests/Query/SimpleQueryNpgsqlTest.Functions.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/SimpleQueryNpgsqlTest.Functions.cs
@@ -32,8 +32,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
 
         public override async Task String_StartsWith_Column(bool isAsync)
         {
-            await AssertQuery<Customer>(isAsync, cs => cs.Where(c => c.ContactName.StartsWith(c.City)));
-            AssertContainsSqlFragment(@"WHERE c.""ContactName"" LIKE (c.""City"" || '%') AND (LEFT(c.""ContactName"", LENGTH(c.""City"")) = c.""City"")");
+            await base.String_StartsWith_Column(isAsync);
+
+            AssertContainsSqlFragment(@"WHERE c.""ContactName"" LIKE c.""ContactName"" || '%' AND ((LEFT(c.""ContactName"", LENGTH(c.""ContactName"")) = c.""ContactName"") OR c.""ContactName"" IS NULL)");
         }
 
         public override async Task String_EndsWith_Literal(bool isAsync)

--- a/test/EFCore.PG.FunctionalTests/Query/SimpleQueryNpgsqlTest.Where.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/SimpleQueryNpgsqlTest.Where.cs
@@ -90,14 +90,13 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
                 oc => oc.Where(o =>
                     o.OrderDate.Value.DayOfWeek == DayOfWeek.Tuesday),
                 entryCount: 168);
-            AssertContainsSqlFragment("WHERE CAST(FLOOR(DATE_PART('dow', o.\"OrderDate\")) AS integer)");
+            AssertContainsSqlFragment("WHERE CAST(FLOOR(DATE_PART('dow', o.\"OrderDate\")) AS int)");
         }
-
 
         public override async Task Where_string_indexof(bool isAsync)
         {
             await base.Where_string_indexof(isAsync);
-            AssertContainsSqlFragment("WHERE (STRPOS(c.\"City\", 'Sea') - 1) <> -1");
+            AssertContainsSqlFragment("WHERE ((STRPOS(c.\"City\", 'Sea') - 1) <> -1)");
         }
     }
 }

--- a/test/EFCore.PG.FunctionalTests/Query/UdfDbFunctionNpgsqlTests.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/UdfDbFunctionNpgsqlTests.cs
@@ -138,7 +138,7 @@ WHERE is_top_customer(c.""Id"") = TRUE");
             base.Scalar_Function_Where_Not_Correlated_Static();
 
             AssertSql(
-                @"@__startDate_0='2000-04-01T00:00:00' (DbType = DateTime)
+                @"@__startDate_0='2000-04-01T00:00:00' (Nullable = true) (DbType = DateTime)
 
 SELECT c.""Id""
 FROM ""Customers"" AS c
@@ -519,7 +519,7 @@ WHERE is_top_customer(c.""Id"") = TRUE");
             base.Scalar_Function_Where_Not_Correlated_Instance();
 
             AssertSql(
-                @"@__startDate_1='2000-04-01T00:00:00' (DbType = DateTime)
+                @"@__startDate_1='2000-04-01T00:00:00' (Nullable = true) (DbType = DateTime)
 
 SELECT c.""Id""
 FROM ""Customers"" AS c


### PR DESCRIPTION
This makes the provider compile against the recently-released EF Core 3.0.0-preview.18572.1. Some minor changes were necessary, and some tests were disabled because of EF Core-side changes (especially https://github.com/aspnet/EntityFrameworkCore/issues/14159).

All tests pass, once this is merged I'll release our own 3.0.0-preview1.