### PR TITLE
Reset AppVeyor to use default 2.2.100 SDK

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,8 +18,8 @@ clone_depth: 10
 install:
   - powershell .build\setup_appveyor.ps1
   # The following can be used to install a custom version of .NET Core
-  - ps: Invoke-WebRequest -Uri "https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.ps1" -OutFile "install-dotnet.ps1"
-  - ps: ./install-dotnet.ps1 -Version 2.2.100
+  # - ps: Invoke-WebRequest -Uri "https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.ps1" -OutFile "install-dotnet.ps1"
+  # - ps: ./install-dotnet.ps1 -Version 2.2.100
   #
   # - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 before_build:


### PR DESCRIPTION
See: #749

## Related
https://github.com/appveyor/ci/issues/2758
