### PR TITLE
Add Case Insensitive mode 

### DIFF
--- a/src/EFCore.PG/Infrastructure/Internal/INpgsqlOptions.cs
+++ b/src/EFCore.PG/Infrastructure/Internal/INpgsqlOptions.cs
@@ -22,6 +22,11 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal
         bool ReverseNullOrderingEnabled { get; }
 
         /// <summary>
+        /// True if reverse null ordering is enabled; otherwise, false.
+        /// </summary>
+        bool CaseInsensitiveEnabled { get; }
+
+        /// <summary>
         /// The collection of range mappings.
         /// </summary>
         [NotNull]

--- a/src/EFCore.PG/Infrastructure/Internal/NpgsqlOptionsExtension.cs
+++ b/src/EFCore.PG/Infrastructure/Internal/NpgsqlOptionsExtension.cs
@@ -52,6 +52,11 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal
         public bool ReverseNullOrdering { get; private set; }
 
         /// <summary>
+        /// True if reverse null ordering is enabled; otherwise, false.
+        /// </summary>
+        public bool CaseInsensitive { get; private set; }
+
+        /// <summary>
         /// Initializes an instance of <see cref="NpgsqlOptionsExtension"/> with the default settings.
         /// </summary>
         public NpgsqlOptionsExtension()
@@ -70,6 +75,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal
             ProvideClientCertificatesCallback = copyFrom.ProvideClientCertificatesCallback;
             RemoteCertificateValidationCallback = copyFrom.RemoteCertificateValidationCallback;
             ReverseNullOrdering = copyFrom.ReverseNullOrdering;
+            CaseInsensitive = copyFrom.CaseInsensitive;
         }
 
         /// <inheritdoc />
@@ -161,6 +167,20 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal
             var clone = (NpgsqlOptionsExtension)Clone();
 
             clone.ReverseNullOrdering = reverseNullOrdering;
+
+            return clone;
+        }
+
+        /// <summary>
+        /// Returns a copy of the current instance configured with the specified value..
+        /// </summary>
+        /// <param name="caseInsensitive">True to enable case insensitive; otherwise, false.</param>
+        [NotNull]
+        internal virtual NpgsqlOptionsExtension WithCaseInsensitive(bool caseInsensitive)
+        {
+            var clone = (NpgsqlOptionsExtension)Clone();
+
+            clone.CaseInsensitive = caseInsensitive;
 
             return clone;
         }

--- a/src/EFCore.PG/Infrastructure/NpgsqlDbContextOptionsBuilder.cs
+++ b/src/EFCore.PG/Infrastructure/NpgsqlDbContextOptionsBuilder.cs
@@ -86,6 +86,15 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure
         internal virtual void ReverseNullOrdering(bool reverseNullOrdering = true)
             => WithOption(e => e.WithReverseNullOrdering(reverseNullOrdering));
 
+        /// <summary>
+        /// Appends NULLS FIRST to all ORDER BY clauses. This is important for the tests which were written
+        /// for SQL Server. Note that to fully implement null-first ordering indexes also need to be generated
+        /// accordingly, and since this isn't done this feature isn't publicly exposed.
+        /// </summary>
+        /// <param name="reverseNullOrdering">True to enable reverse null ordering; otherwise, false.</param>
+        public virtual void SetCaseInsensitive(bool caseInsensitive = false)
+            => WithOption(e => e.WithCaseInsensitive(caseInsensitive));
+
         #region Authentication
 
         /// <summary>

--- a/src/EFCore.PG/Internal/NpgsqlOptions.cs
+++ b/src/EFCore.PG/Internal/NpgsqlOptions.cs
@@ -19,6 +19,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Internal
         public virtual bool ReverseNullOrderingEnabled { get; private set; }
 
         /// <inheritdoc />
+        public virtual bool CaseInsensitiveEnabled { get; private set; }
+
+        /// <inheritdoc />
         [NotNull]
         public virtual IReadOnlyList<UserRangeDefinition> UserRangeDefinitions { get; private set; }
 
@@ -33,6 +36,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Internal
             PostgresVersion = npgsqlOptions.PostgresVersion;
             ReverseNullOrderingEnabled = npgsqlOptions.ReverseNullOrdering;
             UserRangeDefinitions = npgsqlOptions.UserRangeDefinitions;
+            CaseInsensitiveEnabled = npgsqlOptions.CaseInsensitive;
         }
 
         /// <inheritdoc />

--- a/src/EFCore.PG/Query/Sql/Internal/NpgsqlQuerySqlGenerator.cs
+++ b/src/EFCore.PG/Query/Sql/Internal/NpgsqlQuerySqlGenerator.cs
@@ -542,15 +542,21 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.Sql.Internal
                 .All(p => p.InvariantName != parameterExpression.Name))
             {
                 var parameterType = parameterExpression.Type.UnwrapNullableType();
-                var value = ParameterValues[parameterExpression.Name];
-                var typeMapping = TypeMappingSource.GetMappingForValue(value);
+                var typeMapping = TypeMappingSource.GetMapping(parameterType);
 
-                if (typeMapping == null
-                    || (!typeMapping.ClrType.UnwrapNullableType().IsAssignableFrom(parameterType)
-                        && (parameterType.IsEnum
-                            || !typeof(IConvertible).IsAssignableFrom(parameterType))))
+                if (ParameterValues.ContainsKey(parameterExpression.Name))
                 {
-                    typeMapping = Dependencies.TypeMappingSource.GetMapping(parameterType);
+                    var value = ParameterValues[parameterExpression.Name];
+
+                    typeMapping = TypeMappingSource.GetMappingForValue(value);
+
+                    if (typeMapping == null
+                        || (!typeMapping.ClrType.UnwrapNullableType().IsAssignableFrom(parameterType)
+                            && (parameterType.IsEnum
+                                || !typeof(IConvertible).IsAssignableFrom(parameterType))))
+                    {
+                        typeMapping = TypeMappingSource.GetMapping(parameterType);
+                    }
                 }
 
                 Sql.AddParameter(

--- a/src/EFCore.PG/Query/Sql/Internal/NpgsqlQuerySqlGeneratorFactory.cs
+++ b/src/EFCore.PG/Query/Sql/Internal/NpgsqlQuerySqlGeneratorFactory.cs
@@ -29,6 +29,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.Sql.Internal
                 Dependencies,
                 Check.NotNull(selectExpression, nameof(selectExpression)),
                 _npgsqlOptions.ReverseNullOrderingEnabled,
-                _npgsqlOptions.PostgresVersion);
+                _npgsqlOptions.PostgresVersion,
+                _npgsqlOptions.CaseInsensitiveEnabled);
     }
 }

--- a/test/EFCore.PG.FunctionalTests/Query/CaseInsensitiveQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/CaseInsensitiveQueryNpgsqlTest.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
+{
+    public class WhereCaseInsensitiveNpgsqlTest : SimpleQueryTestBase<NorthwindCaseInsensitiveFixture<NoopModelCustomizer>>
+    {
+        public WhereCaseInsensitiveNpgsqlTest(NorthwindCaseInsensitiveFixture<NoopModelCustomizer> fixture)
+            : base(fixture)
+        {
+        }
+
+        public override async Task Where_simple(bool isAsync)
+        {
+            await base.Where_simple(isAsync);
+
+            AssertContainsSqlFragment("WHERE lower(c.\"City\") = lower('London')");
+        }
+
+        [Fact]
+        public async Task Where_case_insensitive_results_should_be_equals()
+        {
+            using (var context = Fixture.CreateContext())
+            {
+                var small   = context.Customers.FirstOrDefault(x => x.City == "london");
+                var medium  = context.Customers.FirstOrDefault(x => x.City == "loNDOn");
+                var big     = context.Customers.FirstOrDefault(x => x.City == "LONDON");
+
+                Assert.NotNull(small);
+                Assert.NotNull(medium);
+                Assert.NotNull(big);
+
+                var id = small.CustomerID;
+
+                Assert.All(new[] { small, medium, big }, customer => Assert.True(customer.CustomerID == id));
+            }
+        }
+
+        void AssertContainsSqlFragment(string expectedFragment)
+            => Assert.True(Fixture.TestSqlLoggerFactory.SqlStatements.Any(s => s.Contains(expectedFragment)));
+    }
+}

--- a/test/EFCore.PG.FunctionalTests/Query/NorthwindCaseInsensitiveFixture.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/NorthwindCaseInsensitiveFixture.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
+{
+    public class NorthwindCaseInsensitiveFixture<TModelCustomizer> : NorthwindQueryNpgsqlFixture<TModelCustomizer>
+        where TModelCustomizer : IModelCustomizer, new()
+    {
+        public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
+        {
+            new NpgsqlDbContextOptionsBuilder(builder).SetCaseInsensitive(true);
+
+            return base.AddOptions(builder);
+        }
+    }
+}


### PR DESCRIPTION
Hello everyone ;-)!

This feature introduces case insensitive mode for string data filtering by add lower function in where clause. For setup you must invoke SetCaseInsensitive in 

>             new NpgsqlDbContextOptionsBuilder(builder).SetCaseInsensitive(true);

I tried do it in project code standart, so I have hope to good reception :-)!

Ps. This is my first pull request to open source in live ;-)!