### PR TITLE
Fix alter column to serial with schema

### DIFF
--- a/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
@@ -377,12 +377,13 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations
                             newSequenceName = $"{operation.Table}_{operation.Name}_seq";
                             Generate(new CreateSequenceOperation
                             {
+                                Schema = operation.Schema,
                                 Name = newSequenceName,
                                 ClrType = operation.ClrType
                             }, model, builder);
 
                             builder.Append(alterBase).Append("SET");
-                            DefaultValue(null, $@"nextval('{Dependencies.SqlGenerationHelper.DelimitIdentifier(newSequenceName)}')", builder);
+                            DefaultValue(null, $@"nextval('{Dependencies.SqlGenerationHelper.DelimitIdentifier(newSequenceName, operation.Schema)}')", builder);
                             builder.AppendLine(';');
                             // Note: we also need to set the sequence ownership, this is done below after the ALTER COLUMN
                             break;
@@ -417,9 +418,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations
             {
                 builder
                     .Append("ALTER SEQUENCE ")
-                    .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(newSequenceName))
+                    .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(newSequenceName, operation.Schema))
                     .Append(" OWNED BY ")
-                    .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Table))
+                    .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Table, operation.Schema))
                     .Append('.')
                     .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Name))
                     .AppendLine(';');

--- a/test/EFCore.PG.FunctionalTests/NpgsqlMigrationSqlGeneratorTest.cs
+++ b/test/EFCore.PG.FunctionalTests/NpgsqlMigrationSqlGeneratorTest.cs
@@ -478,7 +478,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL
         }
 
         [Fact]
-        public void AlterColumnOperation_int_to_serial()
+        public void AlterColumnOperation_int_to_serial_public()
         {
             Generate(
                 new AlterColumnOperation
@@ -497,6 +497,30 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL
                 @"GO" + EOL + EOL +  // Note that GO here is just a delimiter introduced in the tests to indicate a batch boundary
                 @"ALTER TABLE ""People"" ALTER COLUMN ""IntKey"" SET DEFAULT (nextval('""People_IntKey_seq""'));" + EOL +
                 @"ALTER SEQUENCE ""People_IntKey_seq"" OWNED BY ""People"".""IntKey"";" + EOL,
+                Sql);
+        }
+
+        [Fact]
+        public void AlterColumnOperation_int_to_serial_non_public()
+        {
+            Generate(
+                new AlterColumnOperation
+                {
+                    Schema = "dbo",
+                    Table = "People",
+                    Name = "IntKey",
+                    ClrType = typeof(int),
+                    IsNullable = false,
+                    [NpgsqlAnnotationNames.ValueGenerationStrategy] = NpgsqlValueGenerationStrategy.SerialColumn
+                });
+
+            Assert.Equal(
+                @"ALTER TABLE dbo.""People"" ALTER COLUMN ""IntKey"" TYPE integer;" + EOL +
+                @"ALTER TABLE dbo.""People"" ALTER COLUMN ""IntKey"" SET NOT NULL;" + EOL +
+                @"CREATE SEQUENCE dbo.""People_IntKey_seq"" AS integer START WITH 1 INCREMENT BY 1 NO MINVALUE NO MAXVALUE NO CYCLE;" + EOL +
+                @"GO" + EOL + EOL +  // Note that GO here is just a delimiter introduced in the tests to indicate a batch boundary
+                @"ALTER TABLE dbo.""People"" ALTER COLUMN ""IntKey"" SET DEFAULT (nextval('dbo.""People_IntKey_seq""'));" + EOL +
+                @"ALTER SEQUENCE dbo.""People_IntKey_seq"" OWNED BY dbo.""People"".""IntKey"";" + EOL,
                 Sql);
         }
 


### PR DESCRIPTION
When a regular column is turned into a serial column, we create a new sequence, set its ownership etc. This didn't use to take the schema properly into account; we now create the sequence in the same schema as the table, just as PostgreSQL does.

Fixes #772