### PR TITLE
Bump packages to 2.2.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<Project>
   <PropertyGroup Label="Package Versions">
     <NpgsqlVersion>4.0.4</NpgsqlVersion>
-    <EFCoreVersion>2.2.0</EFCoreVersion>
-    <MicrosoftExtensionsVersion>$(EFCoreVersion)</MicrosoftExtensionsVersion>
+    <EFCoreVersion>2.2.1</EFCoreVersion>
+    <MicrosoftExtensionsVersion>2.2.0</MicrosoftExtensionsVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Note that packages in `Microsoft.Extensions.*` [were not updated](https://github.com/dotnet/core/blob/master/release-notes/2.2/2.2.1/2.2.1.md#packages-updated-in-this-release) in this release.