### PR TITLE
Change technique for comparing without whitespace

### DIFF
--- a/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlCharacterTypeMapping.cs
+++ b/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlCharacterTypeMapping.cs
@@ -70,8 +70,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
         {
             var (i, j) = (0, 0);
 
-            for (i = a.Length - 1; a[i] >= 0 && char.IsWhiteSpace(a[i]); i--) ;
-            for (j = b.Length - 1; b[j] >= 0 && char.IsWhiteSpace(b[j]); j--) ;
+            for (i = a.Length - 1; i >= 0 && char.IsWhiteSpace(a[i]); i--) ;
+            for (j = b.Length - 1; j >= 0 && char.IsWhiteSpace(b[j]); j--) ;
 
             if (i != j)
                 return false;


### PR DESCRIPTION
#567 introduced comparing strings disregarding trailing whitespace for PostgreSQL `CHAR` mapping. This was done using Span, but since then apparently EF Core changed the comparer function to be an expression tree (as opposed to a lambda), and Spans aren't legal there yet.

Replaced with a function that performs character comparison, disregarding trailing nulls.