### PR TITLE
Remove non-generic Npgsql-specific HasIndex extension method

### DIFF
--- a/src/EFCore.PG/Extensions/NpgsqlEntityTypeBuilderExtensions.cs
+++ b/src/EFCore.PG/Extensions/NpgsqlEntityTypeBuilderExtensions.cs
@@ -1,11 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq.Expressions;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
-using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Utilities;
 
 // ReSharper disable once CheckNamespace
@@ -185,40 +181,5 @@ namespace Microsoft.EntityFrameworkCore
             => (EntityTypeBuilder<TEntity>)ForCockroachDbInterleaveInParent((EntityTypeBuilder)entityTypeBuilder, parentTableType, interleavePrefix);
 
         #endregion CockroachDB Interleave-in-parent
-
-        #region Generic Index
-
-        /// <summary>
-        /// Configures an index on the specified properties. If there is an existing index on the given
-        /// set of properties, then the existing index will be returned for configuration.
-        /// </summary>
-        /// <typeparam name="TEntity"> The entity type being configured. </typeparam>
-        /// <param name="entityTypeBuilder"> The builder for the entity type being configured. </param>
-        /// <param name="indexExpression">
-        ///   <para>
-        ///     A lambda expression representing the property(s) to be included in the index
-        ///     (<c>blog => blog.Url</c>).
-        ///   </para>
-        ///   <para>
-        ///     If the index is made up of multiple properties then specify an anonymous type including the
-        ///     properties (<c>post => new { post.Title, post.BlogId }</c>).
-        ///   </para>
-        /// </param>
-        /// <returns> An object that can be used to configure the index. </returns>
-        public static IndexBuilder<TEntity> ForNpgsqlHasIndex<TEntity>(
-            [NotNull] this EntityTypeBuilder<TEntity> entityTypeBuilder,
-            [NotNull] Expression<Func<TEntity, object>> indexExpression)
-            where TEntity : class
-        {
-            Check.NotNull(entityTypeBuilder, nameof(entityTypeBuilder));
-            Check.NotNull(indexExpression, nameof(indexExpression));
-
-            var builder = ((IInfrastructure<InternalEntityTypeBuilder>)entityTypeBuilder).GetInfrastructure();
-
-            return new IndexBuilder<TEntity>(
-                builder.HasIndex(indexExpression.GetPropertyAccessList(), ConfigurationSource.Explicit));
-        }
-
-        #endregion
     }
 }


### PR DESCRIPTION
Re: https://github.com/npgsql/Npgsql.EntityFrameworkCore.PostgreSQL/issues/813. Follows EF Core's lead; https://github.com/aspnet/EntityFrameworkCore/pull/14641.