### PR TITLE
Support faceted spatial store type names

### DIFF
--- a/src/EFCore.PG.NTS/Storage/Internal/NpgsqlGeometryTypeMapping.cs
+++ b/src/EFCore.PG.NTS/Storage/Internal/NpgsqlGeometryTypeMapping.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Data.Common;
 using System.Text;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -16,8 +16,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
     {
         readonly bool _isGeography;
 
-        public NpgsqlGeometryTypeMapping(string storeType) : base(new NullValueConverter(), storeType)
-            => _isGeography = IsGeography(storeType);
+        public NpgsqlGeometryTypeMapping(string storeType, bool isGeography) : base(new NullValueConverter(), storeType)
+            => _isGeography = isGeography;
 
         protected NpgsqlGeometryTypeMapping(RelationalTypeMappingParameters parameters)
             : base(parameters, new NullValueConverter()) {}
@@ -55,9 +55,6 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
 
             return builder.ToString();
         }
-
-        static bool IsGeography(string storeType)
-            => string.Equals(storeType, "geography", StringComparison.OrdinalIgnoreCase);
 
         class NullValueConverter : ValueConverter<TGeometry, TGeometry>
         {

--- a/src/EFCore.PG.NTS/Storage/Internal/NpgsqlNetTopologySuiteTypeMappingSourcePlugin.cs
+++ b/src/EFCore.PG.NTS/Storage/Internal/NpgsqlNetTopologySuiteTypeMappingSourcePlugin.cs
@@ -19,18 +19,66 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
 
         public virtual RelationalTypeMapping FindMapping(in RelationalTypeMappingInfo mappingInfo)
         {
+            // TODO: Array
             var clrType = mappingInfo.ClrType;
             var storeTypeName = mappingInfo.StoreTypeName;
+            var isGeography = _options.IsGeographyDefault;
 
-            // TODO: Array
-            return clrType != null && typeof(IGeometry).IsAssignableFrom(clrType) ||
-                   storeTypeName != null && (
-                        storeTypeName.Equals("geometry", StringComparison.OrdinalIgnoreCase) ||
-                        storeTypeName.Equals("geography", StringComparison.OrdinalIgnoreCase))
+            if (storeTypeName != null && !TryParseStoreTypeName(storeTypeName, out isGeography, out var _, out var _))
+                return null;
+            if (clrType != null && !typeof(IGeometry).IsAssignableFrom(clrType))
+                return null;
+
+            return clrType != null || storeTypeName != null
                 ? (RelationalTypeMapping)Activator.CreateInstance(
                     typeof(NpgsqlGeometryTypeMapping<>).MakeGenericType(clrType ?? typeof(IGeometry)),
-                    storeTypeName ?? (_options.IsGeographyDefault ? "geography" : "geometry"))
+                    storeTypeName ?? (isGeography ? "geography" : "geometry"),
+                    isGeography)
                 : null;
+        }
+
+        /// <summary>
+        /// Given a PostGIS store type name (e.g. GEOMETRY, GEOGRAPHY(Point, 4326)), attempts to parse it and return its components.
+        /// </summary>
+        public static bool TryParseStoreTypeName(string storeTypeName, out bool isGeography, out string subType, out int srid)
+        {
+            isGeography = false;
+            subType = null;
+            srid = -1;
+
+            var openParen = storeTypeName.IndexOf("(", StringComparison.Ordinal);
+
+            var baseType = (openParen > 0
+                ? storeTypeName.Substring(0, openParen)
+                : storeTypeName)
+                .Trim();
+
+            if (baseType.Equals("geometry", StringComparison.OrdinalIgnoreCase))
+                isGeography = false;
+            else if (baseType.Equals("geography", StringComparison.OrdinalIgnoreCase))
+                isGeography = true;
+            else
+                return false;
+
+            if (openParen == -1)
+                return true;
+
+            var closeParen = storeTypeName.IndexOf(")", openParen + 1, StringComparison.Ordinal);
+            if (closeParen > openParen)
+            {
+                var comma = storeTypeName.IndexOf(",", openParen + 1, StringComparison.Ordinal);
+                if (comma > openParen && comma < closeParen)
+                {
+                    subType = storeTypeName.Substring(openParen + 1, comma - openParen - 1).Trim();
+
+                    if (!int.TryParse(storeTypeName.Substring(comma + 1, closeParen - comma - 1).Trim(), out srid))
+                        return false;
+                }
+                else
+                    subType = storeTypeName.Substring(openParen + 1, closeParen - openParen - 1).Trim();
+            }
+
+            return true;
         }
     }
 }

--- a/src/EFCore.PG.NTS/Storage/Internal/NpgsqlNetTopologySuiteTypeMappingSourcePlugin.cs
+++ b/src/EFCore.PG.NTS/Storage/Internal/NpgsqlNetTopologySuiteTypeMappingSourcePlugin.cs
@@ -81,26 +81,23 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
             if (openParen == -1)
                 return true;
 
-            string subTypeString = null;
             var closeParen = storeTypeName.IndexOf(")", openParen + 1, StringComparison.Ordinal);
-            if (closeParen > openParen)
-            {
-                var comma = storeTypeName.IndexOf(",", openParen + 1, StringComparison.Ordinal);
-                if (comma > openParen && comma < closeParen)
-                {
-                    subTypeString = storeTypeName.Substring(openParen + 1, comma - openParen - 1).Trim();
-
-                    if (!int.TryParse(storeTypeName.Substring(comma + 1, closeParen - comma - 1).Trim(), out srid))
-                        return false;
-                }
-                else
-                    subTypeString = storeTypeName.Substring(openParen + 1, closeParen - openParen - 1).Trim();
-            }
-
-            if (subTypeString != null && !SubTypeNameToClrType.TryGetValue(subTypeString, out clrType))
+            if (closeParen == -1)
                 return false;
 
-            return true;
+            string subTypeString;
+            var comma = storeTypeName.IndexOf(",", openParen + 1, StringComparison.Ordinal);
+            if (comma > openParen && comma < closeParen)
+            {
+                subTypeString = storeTypeName.Substring(openParen + 1, comma - openParen - 1).Trim();
+
+                if (!int.TryParse(storeTypeName.Substring(comma + 1, closeParen - comma - 1).Trim(), out srid))
+                    return false;
+            }
+            else
+                subTypeString = storeTypeName.Substring(openParen + 1, closeParen - openParen - 1).Trim();
+
+            return SubTypeNameToClrType.TryGetValue(subTypeString, out clrType);
         }
     }
 }

--- a/test/EFCore.PG.Tests/EFCore.PG.Tests.csproj
+++ b/test/EFCore.PG.Tests/EFCore.PG.Tests.csproj
@@ -15,6 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\EFCore.PG.NTS\EFCore.PG.NTS.csproj" />
     <ProjectReference Include="..\..\src\EFCore.PG\EFCore.PG.csproj" />
     <ProjectReference Include="..\EFCore.PG.FunctionalTests\EFCore.PG.FunctionalTests.csproj" />
   </ItemGroup>

--- a/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingSourceTest.cs
+++ b/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingSourceTest.cs
@@ -22,8 +22,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage
         [InlineData("floatrange", typeof(NpgsqlRange<float>))]
         [InlineData("dummyrange", typeof(NpgsqlRange<DummyType>))]
         [InlineData("geometry", typeof(IGeometry))]
-        [InlineData("geometry(Polygon)", typeof(IGeometry))]
-        [InlineData("geography(Point, 4326)", typeof(IGeometry))]
+        [InlineData("geometry(Polygon)", typeof(IPolygon))]
+        [InlineData("geography(Point, 4326)", typeof(IPoint))]
         public void By_StoreType(string storeType, Type expectedClrType)
             => Assert.Same(expectedClrType, Source.FindMapping(storeType).ClrType);
 

--- a/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingSourceTest.cs
+++ b/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingSourceTest.cs
@@ -2,6 +2,8 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using GeoAPI.Geometries;
+using NetTopologySuite.Geometries;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Internal;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal;
@@ -19,6 +21,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage
         [InlineData("int4range", typeof(NpgsqlRange<int>))]
         [InlineData("floatrange", typeof(NpgsqlRange<float>))]
         [InlineData("dummyrange", typeof(NpgsqlRange<DummyType>))]
+        [InlineData("geometry", typeof(IGeometry))]
+        [InlineData("geometry(Polygon)", typeof(IGeometry))]
+        [InlineData("geography(Point, 4326)", typeof(IGeometry))]
         public void By_StoreType(string storeType, Type expectedClrType)
             => Assert.Same(expectedClrType, Source.FindMapping(storeType).ClrType);
 
@@ -29,6 +34,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage
         [InlineData(typeof(NpgsqlRange<int>), "int4range")]
         [InlineData(typeof(NpgsqlRange<float>), "floatrange")]
         [InlineData(typeof(NpgsqlRange<DummyType>), "dummyrange")]
+        [InlineData(typeof(IGeometry), "geometry")]
+        [InlineData(typeof(IPoint), "geometry")]
+        [InlineData(typeof(Point), "geometry")]
         public void By_ClrType(Type clrType, string expectedStoreType)
             => Assert.Equal(expectedStoreType, ((RelationalTypeMapping)Source.FindMapping(clrType)).StoreType);
 
@@ -39,6 +47,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage
         [InlineData("int4range", typeof(NpgsqlRange<int>))]
         [InlineData("floatrange", typeof(NpgsqlRange<float>))]
         [InlineData("dummyrange", typeof(NpgsqlRange<DummyType>))]
+        [InlineData("geometry", typeof(IGeometry))]
+        [InlineData("geometry(Point, 4326)", typeof(IGeometry))]
         public void By_StoreType_with_ClrType(string storeType, Type clrType)
             => Assert.Equal(storeType, Source.FindMapping(clrType, storeType).StoreType);
 
@@ -49,6 +59,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage
         [InlineData("int4range", typeof(UnknownType))]
         [InlineData("floatrange", typeof(UnknownType))]
         [InlineData("dummyrange", typeof(UnknownType))]
+        [InlineData("geometry", typeof(UnknownType))]
         public void By_StoreType_with_wrong_ClrType(string storeType, Type wrongClrType)
             => Assert.Null(Source.FindMapping(wrongClrType, storeType));
 
@@ -72,7 +83,10 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage
                     new ValueConverterSelector(new ValueConverterSelectorDependencies()),
                     Array.Empty<ITypeMappingSourcePlugin>()),
                 new RelationalTypeMappingSourceDependencies(
-                    new[] { new DummyTypeMappingSourcePlugin() }),
+                    new IRelationalTypeMappingSourcePlugin[] {
+                        new NpgsqlNetTopologySuiteTypeMappingSourcePlugin(new NpgsqlNetTopologySuiteOptions()),
+                        new DummyTypeMappingSourcePlugin()
+                    }),
                 new NpgsqlSqlGenerationHelper(new RelationalSqlGenerationHelperDependencies()),
                 options);
         }


### PR DESCRIPTION
When dealing with spatial store type names (e.g. scaffolding), we
supported geometry/geography, but only when no facets were
specified. We now support geometry(point,4326) etc.

Fixes #818