### PR TITLE
[WIP] Update doc as #821.

### DIFF
--- a/doc/modeling/indexes.md
+++ b/doc/modeling/indexes.md
@@ -9,8 +9,8 @@ Since version 11, PostgreSQL supports [covering indexes](https://paquier.xyz/pos
 ```c#
 protected override void OnModelCreating(ModelBuilder modelBuilder)
     => modelBuilder.Entity<Blog>()
-                   .ForNpgsqlHasIndex(b => b.Id)
-                   .ForNpgsqlInclude(b => b.Name);
+                   .HasIndex(b => b.Id)
+                   .ForNpgsqlInclude("Name");
 ```
 
 This will create an index for searching on `Id`, but containing also the column `Name`, so that reading the latter will not involve accessing the table. The SQL generated is as follows:

--- a/doc/modeling/indexes.md
+++ b/doc/modeling/indexes.md
@@ -10,7 +10,7 @@ Since version 11, PostgreSQL supports [covering indexes](https://paquier.xyz/pos
 protected override void OnModelCreating(ModelBuilder modelBuilder)
     => modelBuilder.Entity<Blog>()
                    .HasIndex(b => b.Id)
-                   .ForNpgsqlInclude("Name");
+                   .ForNpgsqlInclude(nameof(b.Name));
 ```
 
 This will create an index for searching on `Id`, but containing also the column `Name`, so that reading the latter will not involve accessing the table. The SQL generated is as follows:

--- a/doc/modeling/indexes.md
+++ b/doc/modeling/indexes.md
@@ -10,7 +10,7 @@ Since version 11, PostgreSQL supports [covering indexes](https://paquier.xyz/pos
 protected override void OnModelCreating(ModelBuilder modelBuilder)
     => modelBuilder.Entity<Blog>()
                    .HasIndex(b => b.Id)
-                   .ForNpgsqlInclude(nameof(b.Name));
+                   .ForNpgsqlInclude(b => b.Name);
 ```
 
 This will create an index for searching on `Id`, but containing also the column `Name`, so that reading the latter will not involve accessing the table. The SQL generated is as follows:


### PR DESCRIPTION
~`HasIndex(Expression<Func<TEntity,Object>>)` returns `IndexBuilder` instead of `IndexBuilder<TEntity>`, so no overload of `ForNpgsqlInclude` accept `Expression<Func<TEntity, object>>` now.~

This could be merged after targeting a newer version of EFCore, which has the corresponding `HasIndex()` overload.