### PR TITLE
Upgrade to .Net Core v3.0.0-preview2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup Label="Package Versions">
     <VersionPrefix>3.0.0</VersionPrefix>
     <NpgsqlVersion>4.0.4</NpgsqlVersion>
-    <EFCoreVersion>3.0.0-preview.18572.1</EFCoreVersion>
+    <EFCoreVersion>3.0.0-preview.19074.3</EFCoreVersion>
     <MicrosoftExtensionsVersion>$(EFCoreVersion)</MicrosoftExtensionsVersion>
   </PropertyGroup>
 </Project>

--- a/src/EFCore.PG.NTS/Infrastructure/Internal/NpgsqlNetTopologySuiteOptionsExtension.cs
+++ b/src/EFCore.PG.NTS/Infrastructure/Internal/NpgsqlNetTopologySuiteOptionsExtension.cs
@@ -14,7 +14,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Utilities;
 // ReSharper disable once CheckNamespace
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal
 {
-    public class NpgsqlNetTopologySuiteOptionsExtension : IDbContextOptionsExtensionWithDebugInfo
+    public class NpgsqlNetTopologySuiteOptionsExtension : IDbContextOptionsExtension
     {
         bool _isGeographyDefault;
         string _logFragment;

--- a/src/EFCore.PG.NodaTime/Infrastructure/Internal/NpgsqlNodaTimeOptionsExtension.cs
+++ b/src/EFCore.PG.NodaTime/Infrastructure/Internal/NpgsqlNodaTimeOptionsExtension.cs
@@ -23,6 +23,10 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal
 
         public virtual long GetServiceProviderHashCode() => 0;
 
+        public void PopulateDebugInfo(IDictionary<string, string> debugInfo)
+        {
+        }
+
         public virtual void Validate(IDbContextOptions options)
         {
             var internalServiceProvider = options.FindExtension<CoreOptionsExtension>()?.InternalServiceProvider;

--- a/src/EFCore.PG/Infrastructure/Internal/NpgsqlOptionsExtension.cs
+++ b/src/EFCore.PG/Infrastructure/Internal/NpgsqlOptionsExtension.cs
@@ -195,6 +195,12 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal
             return clone;
         }
 
+        public override void PopulateDebugInfo(IDictionary<string, string> debugInfo)
+        {
+            // We might want to add the current values of AdminDatabase, PostgresVersion, ReverseNullOrdering, _userRangeDefinitions
+            // and the certificates callbacks here.
+        }
+
         #endregion Authentication
     }
 

--- a/src/EFCore.PG/Infrastructure/Internal/NpgsqlOptionsExtension.cs
+++ b/src/EFCore.PG/Infrastructure/Internal/NpgsqlOptionsExtension.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Security;
+using System.Text;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
@@ -15,6 +16,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal
     public class NpgsqlOptionsExtension : RelationalOptionsExtension
     {
         [NotNull] readonly List<UserRangeDefinition> _userRangeDefinitions;
+        string _logFragment;
 
         /// <summary>
         /// The name of the database for administrative operations.
@@ -89,6 +91,70 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal
         // The following is a hack to set the default minimum batch size to 2 in Npgsql
         // See https://github.com/aspnet/EntityFrameworkCore/pull/10091
         public override int? MinBatchSize => base.MinBatchSize ?? 2;
+
+        /// <inheritdoc />
+        [NotNull]
+        public override string LogFragment
+        {
+            get
+            {
+                if (_logFragment == null)
+                {
+                    var builder = new StringBuilder(base.LogFragment);
+
+                    if (AdminDatabase != null)
+                    {
+                        builder.Append("AdminDatabase=").Append(AdminDatabase).Append(' ');
+                    }
+
+                    if (PostgresVersion != null)
+                    {
+                        builder.Append("PostgresVersion=").Append(PostgresVersion).Append(' ');
+                    }
+
+                    if (ProvideClientCertificatesCallback != null)
+                    {
+                        builder.Append("ProvideClientCertificatesCallback ");
+                    }
+
+                    if (RemoteCertificateValidationCallback != null)
+                    {
+                        builder.Append("RemoteCertificateValidationCallback ");
+                    }
+
+                    if (ReverseNullOrdering)
+                    {
+                        builder.Append("ReverseNullOrdering ");
+                    }
+
+                    if (UserRangeDefinitions.Count > 0)
+                    {
+                        builder.Append("UserRangeDefinitions=[");
+                        foreach (var item in UserRangeDefinitions)
+                        {
+                            builder.Append(item.SubtypeClrType).Append("=>");
+
+                            if (item.SchemaName != null)
+                                builder.Append(item.SchemaName).Append(".");
+
+                            builder.Append(item.RangeName);
+
+                            if(item.SubtypeName != null)
+                                builder.Append("(").Append(item.SubtypeName).Append(")");
+
+                            builder.Append(";");
+                        }
+
+                        builder.Length = builder.Length -1;
+
+                        builder.Append("] ");
+                    }
+
+                    _logFragment = builder.ToString();
+                }
+                return _logFragment;
+            }
+        }
 
         /// <summary>
         /// Returns a copy of the current instance configured with the specified range mapping.

--- a/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
@@ -339,7 +339,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations
             if (IsSystemColumn(operation.Name))
                 return;
 
-            var type = operation.ColumnType ?? GetColumnType(operation.Schema, operation.Table, operation.Name, operation.ClrType, null, operation.MaxLength, false, model);
+            var type = operation.ColumnType ?? GetColumnType(operation.Schema, operation.Table, operation.Name, operation.ClrType, null, operation.MaxLength, operation.IsFixedLength, false, model);
 
             string newSequenceName = null;
             var defaultValueSql = operation.DefaultValueSql;

--- a/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlCharacterTypeMapping.cs
+++ b/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlCharacterTypeMapping.cs
@@ -26,7 +26,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
         /// </remarks>
         [NotNull] static readonly ValueComparer<string> CharacterValueComparer =
             new ValueComparer<string>(
-                (x, y) => x != null && y != null && x.AsSpan().TrimEnd() == y.AsSpan().TrimEnd(),
+                (x, y) => x != null && y != null && x.TrimEnd() == y.TrimEnd(),
                 x => x != null ? x.TrimEnd().GetHashCode() : 0);
 
         public override ValueComparer Comparer => CharacterValueComparer;

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -9,9 +9,9 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <!-- Using xunit.core and .assert instead of the main package because compilation fails due to warnings triggered by xunit.analyzers. -->
     <!-- <PackageReference Include="xunit" Version="$(XunitPackageVersion)" /> -->
-    <PackageReference Include="xunit.core" Version="2.4.1" />
-    <PackageReference Include="xunit.assert" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="xunit.core" Version="2.4.1-pre.build.4059" />
+    <PackageReference Include="xunit.assert" Version="2.4.1-pre.build.4059" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1-pre.build.4059" />
     <PackageReference Include="Npgsql" Version="$(NpgsqlVersion)" />
   </ItemGroup>
 </Project>

--- a/test/EFCore.PG.FunctionalTests/EFCore.PG.FunctionalTests.csproj
+++ b/test/EFCore.PG.FunctionalTests/EFCore.PG.FunctionalTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.2</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' OR '$(CoreOnly)' == 'True'">netcoreapp2.2</TargetFrameworks>
     <AssemblyName>Npgsql.EntityFrameworkCore.PostgreSQL.FunctionalTests</AssemblyName>
     <RootNamespace>Npgsql.EntityFrameworkCore.PostgreSQL</RootNamespace>

--- a/test/EFCore.PG.FunctionalTests/LoggingNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/LoggingNpgsqlTest.cs
@@ -1,21 +1,68 @@
-﻿using System;
+using System;
+using System.Net.Security;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal;
+using Xunit;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL
 {
     public class LoggingNpgsqlTest : LoggingRelationalTestBase<NpgsqlDbContextOptionsBuilder, NpgsqlOptionsExtension>
     {
-        /*
         [Fact]
         public void Logs_context_initialization_admin_database()
         {
+            const string testValue = "foo";
             Assert.Equal(
-                ExpectedMessage("AdminDatabase " + DefaultOptions),
-                ActualMessage(CreateOptionsBuilder(b => ((NpgsqlDbContextOptionsBuilder)b).UseAdminDatabase("foo"))));
-        }*/
+                ExpectedMessage($"AdminDatabase={testValue} " + DefaultOptions),
+                ActualMessage(CreateOptionsBuilder(b => ((NpgsqlDbContextOptionsBuilder)b).UseAdminDatabase(testValue))));
+        }
+
+        [Fact]
+        public void Logs_context_initialization_postgres_version()
+        {
+            const string testValue = "10.7";
+            Assert.Equal(
+                ExpectedMessage($"PostgresVersion={testValue} " + DefaultOptions),
+                ActualMessage(CreateOptionsBuilder(b => ((NpgsqlDbContextOptionsBuilder)b).SetPostgresVersion(Version.Parse(testValue)))));
+        }
+
+        [Fact]
+        public void Logs_context_initialization_provide_client_certificates_callback()
+        {
+            ProvideClientCertificatesCallback testCallback = (certificates) => { };
+            Assert.Equal(
+                ExpectedMessage($"ProvideClientCertificatesCallback " + DefaultOptions),
+                ActualMessage(CreateOptionsBuilder(b => ((NpgsqlDbContextOptionsBuilder)b).ProvideClientCertificatesCallback(testCallback))));
+        }
+
+        [Fact]
+        public void Logs_context_initialization_remote_certificate_validation_callback()
+        {
+            RemoteCertificateValidationCallback testCallback = (sender, certificate, chain, sslPolicyErrors) => true;
+            Assert.Equal(
+                ExpectedMessage($"RemoteCertificateValidationCallback " + DefaultOptions),
+                ActualMessage(CreateOptionsBuilder(b => ((NpgsqlDbContextOptionsBuilder)b).RemoteCertificateValidationCallback(testCallback))));
+        }
+
+        [Fact]
+        public void Logs_context_initialization_reverse_null_ordering()
+        {
+            RemoteCertificateValidationCallback testCallback = (sender, certificate, chain, sslPolicyErrors) => true;
+            Assert.Equal(
+                ExpectedMessage($"ReverseNullOrdering " + DefaultOptions),
+                ActualMessage(CreateOptionsBuilder(b => ((NpgsqlDbContextOptionsBuilder)b).ReverseNullOrdering())));
+        }
+
+        [Fact]
+        public void Logs_context_initialization_user_range_definitions()
+        {
+            RemoteCertificateValidationCallback testCallback = (sender, certificate, chain, sslPolicyErrors) => true;
+            Assert.Equal(
+                ExpectedMessage($"UserRangeDefinitions=[{typeof(int)}=>int4range] " + DefaultOptions),
+                ActualMessage(CreateOptionsBuilder(b => ((NpgsqlDbContextOptionsBuilder)b).MapRange<int>("int4range"))));
+        }
 
         protected override DbContextOptionsBuilder CreateOptionsBuilder(
             Action<RelationalDbContextOptionsBuilder<NpgsqlDbContextOptionsBuilder, NpgsqlOptionsExtension>> relationalAction)

--- a/test/EFCore.PG.Plugins.FunctionalTests/EFCore.PG.Plugins.FunctionalTests.csproj
+++ b/test/EFCore.PG.Plugins.FunctionalTests/EFCore.PG.Plugins.FunctionalTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.2</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' OR '$(CoreOnly)' == 'True'">netcoreapp2.2</TargetFrameworks>
     <AssemblyName>Npgsql.EntityFrameworkCore.PostgreSQL.Plugins.FunctionalTests</AssemblyName>
     <RootNamespace>Npgsql.EntityFrameworkCore.PostgreSQL</RootNamespace>

--- a/test/EFCore.PG.Tests/EFCore.PG.Tests.csproj
+++ b/test/EFCore.PG.Tests/EFCore.PG.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.2</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' OR '$(CoreOnly)' == 'True'">netcoreapp2.2</TargetFrameworks>
     <AssemblyName>Npgsql.EntityFrameworkCore.PostgreSQL.Tests</AssemblyName>
     <RootNamespace>Npgsql.EntityFrameworkCore.PostgreSQL</RootNamespace>


### PR DESCRIPTION
As mentioned in #806 this would be necessary to create some basic compatibility with .Net Core v3.0.0-preview2 which has been released 2019-01-29

I recognize there are quite a few (66 on my machine) test failures that I can't really trace down to my changes but that might be interesting.

I'm marking this as draft PR as in its current state it certainly isn't ready to merge but I'm interested in feedback anyways.
