### PR TITLE
Add literal code generation for some NodaTime types

### DIFF
--- a/src/EFCore.PG.NodaTime/Storage/Internal/NodaTimeMappings.cs
+++ b/src/EFCore.PG.NodaTime/Storage/Internal/NodaTimeMappings.cs
@@ -1,9 +1,12 @@
-﻿using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using NodaTime.Text;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping;
 using NpgsqlTypes;
+using System.Linq.Expressions;
+using System.Reflection;
+using static Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime.Utilties.Util;
 
 // ReSharper disable once CheckNamespace
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
@@ -25,10 +28,23 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
 
         protected override string GenerateNonNullSqlLiteral(object value)
             => $"TIMESTAMP '{InstantPattern.ExtendedIso.Format((Instant)value)}'";
+
+        // GenerateCodeLiteral isn't implemented because round-tripping Instant would require rendering an expression such as
+        // NodaConstants.UnixEpoch + Duration.FromNanoseconds(nanoseconds), which isn't currently supported by EF Core's code
+        // generator
     }
 
     public class TimestampLocalDateTimeMapping : NpgsqlTypeMapping
     {
+        static readonly ConstructorInfo _ctorInfo1 =
+            typeof(LocalDateTime).GetConstructor(new[] { typeof(int), typeof(int), typeof(int), typeof(int), typeof(int) });
+
+        static readonly ConstructorInfo _ctorInfo2 =
+            typeof(LocalDateTime).GetConstructor(new[] { typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int) });
+
+        static readonly MethodInfo _plusNanosecondsMethodInfo =
+            typeof(LocalDateTime).GetMethod(nameof(LocalDateTime.PlusNanoseconds), new[] { typeof(long) });
+
         public TimestampLocalDateTimeMapping() : base("timestamp", typeof(LocalDateTime), NpgsqlDbType.Timestamp) {}
 
         protected TimestampLocalDateTimeMapping(RelationalTypeMappingParameters parameters)
@@ -42,6 +58,20 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
 
         protected override string GenerateNonNullSqlLiteral(object value)
             => $"TIMESTAMP '{LocalDateTimePattern.ExtendedIso.Format((LocalDateTime)value)}'";
+
+        public override Expression GenerateCodeLiteral(object value) => GenerateCodeLiteral((LocalDateTime)value);
+
+        internal static Expression GenerateCodeLiteral(LocalDateTime dateTime)
+        {
+            if (dateTime.Second == 0 && dateTime.NanosecondOfSecond == 0)
+                return ConstantNew(_ctorInfo1, dateTime.Year, dateTime.Month, dateTime.Day, dateTime.Hour, dateTime.Minute);
+
+            var newExpr = ConstantNew(_ctorInfo2, dateTime.Year, dateTime.Month, dateTime.Day, dateTime.Hour, dateTime.Minute, dateTime.Second);
+
+            return dateTime.NanosecondOfSecond == 0
+                ? (Expression)newExpr
+                : Expression.Call(newExpr, _plusNanosecondsMethodInfo, Expression.Constant((long)dateTime.NanosecondOfSecond));
+        }
     }
 
     #endregion timestamp
@@ -63,10 +93,23 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
 
         protected override string GenerateNonNullSqlLiteral(object value)
             => $"TIMESTAMPTZ '{InstantPattern.ExtendedIso.Format((Instant)value)}'";
+
+        // GenerateCodeLiteral isn't implemented because round-tripping Instant would require rendering an expression such as
+        // NodaConstants.UnixEpoch + Duration.FromNanoseconds(nanoseconds), which isn't currently supported by EF Core's code
+        // generator
     }
 
     public class TimestampTzOffsetDateTimeMapping : NpgsqlTypeMapping
     {
+        static readonly ConstructorInfo _ctorInfo =
+            typeof(OffsetDateTime).GetConstructor(new[] { typeof(LocalDateTime), typeof(Offset) });
+
+        static readonly MethodInfo _offsetFactoryMethodInfo1 =
+            typeof(Offset).GetMethod(nameof(Offset.FromHours), new[] { typeof(int) });
+
+        static readonly MethodInfo _offsetFactoryMethodInfo2 =
+            typeof(Offset).GetMethod(nameof(Offset.FromSeconds), new[] { typeof(int) });
+
         public TimestampTzOffsetDateTimeMapping() : base("timestamp with time zone", typeof(OffsetDateTime), NpgsqlDbType.TimestampTz) {}
 
         protected TimestampTzOffsetDateTimeMapping(RelationalTypeMappingParameters parameters)
@@ -80,6 +123,18 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
 
         protected override string GenerateNonNullSqlLiteral(object value)
             => $"TIMESTAMPTZ '{OffsetDateTimePattern.ExtendedIso.Format((OffsetDateTime)value)}'";
+
+        public override Expression GenerateCodeLiteral(object value)
+        {
+            var offsetDateTime = (OffsetDateTime)value;
+            var offsetSeconds = offsetDateTime.Offset.Seconds;
+
+            return Expression.New(_ctorInfo,
+                TimestampLocalDateTimeMapping.GenerateCodeLiteral(offsetDateTime.LocalDateTime),
+                offsetSeconds % 3600 == 0
+                    ? ConstantCall(_offsetFactoryMethodInfo1, offsetSeconds / 3600)
+                    : ConstantCall(_offsetFactoryMethodInfo2, offsetSeconds));
+        }
     }
 
     public class TimestampTzZonedDateTimeMapping : NpgsqlTypeMapping
@@ -101,6 +156,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
 
         protected override string GenerateNonNullSqlLiteral(object value)
             => $"TIMESTAMPTZ '{Pattern.Format((ZonedDateTime)value)}'";
+
+        // GenerateCodeLiteral isn't implemented because round-tripping DateTimeZone would require a property access into
+        // DateTimeZoneProviders, which isn't currently supported by EF Core's code generator
     }
 
     #endregion timestamptz
@@ -109,6 +167,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
 
     public class DateMapping : NpgsqlTypeMapping
     {
+        static readonly ConstructorInfo _ctorInfo =
+            typeof(LocalDate).GetConstructor(new[] { typeof(int), typeof(int), typeof(int) });
+
         public DateMapping() : base("date", typeof(LocalDate), NpgsqlDbType.Date) {}
 
         protected DateMapping(RelationalTypeMappingParameters parameters)
@@ -122,6 +183,12 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
 
         protected override string GenerateNonNullSqlLiteral(object value)
             => $"DATE '{LocalDatePattern.Iso.Format((LocalDate)value)}'";
+
+        public override Expression GenerateCodeLiteral(object value)
+        {
+            var date = (LocalDate)value;
+            return ConstantNew(_ctorInfo, date.Year, date.Month, date.Day);
+        }
     }
 
     #endregion date
@@ -130,6 +197,16 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
 
     public class TimeMapping : NpgsqlTypeMapping
     {
+        static readonly ConstructorInfo _ctorInfo1 =
+            typeof(LocalTime).GetConstructor(new[] { typeof(int), typeof(int) });
+
+        static readonly ConstructorInfo _ctorInfo2 =
+            typeof(LocalTime).GetConstructor(new[] { typeof(int), typeof(int), typeof(int) });
+
+        static readonly MethodInfo _factoryMethodInfo =
+            typeof(LocalTime).GetMethod(nameof(LocalTime.FromHourMinuteSecondNanosecond),
+                new[] { typeof(int), typeof(int), typeof(int), typeof(long) });
+
         public TimeMapping() : base("time", typeof(LocalTime), NpgsqlDbType.Time) {}
 
         protected TimeMapping(RelationalTypeMappingParameters parameters)
@@ -143,6 +220,19 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
 
         protected override string GenerateNonNullSqlLiteral(object value)
             => $"TIME '{LocalTimePattern.ExtendedIso.Format((LocalTime)value)}'";
+
+        public override Expression GenerateCodeLiteral(object value)
+        {
+            var time = (LocalTime)value;
+
+            if (time.NanosecondOfSecond != 0)
+                return ConstantCall(_factoryMethodInfo, time.Hour, time.Minute, time.Second, (long)time.NanosecondOfSecond);
+
+            if (time.Second != 0)
+                return ConstantNew(_ctorInfo2, time.Hour, time.Minute, time.Second);
+
+            return ConstantNew(_ctorInfo1, time.Hour, time.Minute);
+        }
     }
 
     #endregion time
@@ -151,6 +241,25 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
 
     public class TimeTzMapping : NpgsqlTypeMapping
     {
+        static readonly ConstructorInfo _ctorInfo =
+            typeof(OffsetTime).GetConstructor(new[] { typeof(LocalTime), typeof(Offset) });
+
+        static readonly ConstructorInfo _localTimeCtorInfo1 =
+            typeof(LocalTime).GetConstructor(new[] { typeof(int), typeof(int) });
+
+        static readonly ConstructorInfo _localTimeCtorInfo2 =
+            typeof(LocalTime).GetConstructor(new[] { typeof(int), typeof(int), typeof(int) });
+
+        static readonly MethodInfo _localTimeFactoryMethodInfo =
+            typeof(LocalTime).GetMethod(nameof(LocalTime.FromHourMinuteSecondNanosecond),
+                new[] { typeof(int), typeof(int), typeof(int), typeof(long) });
+
+        static readonly MethodInfo _offsetFactoryMethodInfo1 =
+            typeof(Offset).GetMethod(nameof(Offset.FromHours), new[] { typeof(int) });
+
+        static readonly MethodInfo _offsetFactoryMethodInfo2 =
+            typeof(Offset).GetMethod(nameof(Offset.FromSeconds), new[] { typeof(int) });
+
         static readonly OffsetTimePattern Pattern =
             OffsetTimePattern.CreateWithInvariantCulture("HH':'mm':'ss;FFFFFFo<G>");
 
@@ -167,6 +276,26 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
 
         protected override string GenerateNonNullSqlLiteral(object value)
             => $"TIMETZ '{Pattern.Format((OffsetTime)value)}'";
+
+        public override Expression GenerateCodeLiteral(object value)
+        {
+            var offsetTime = (OffsetTime)value;
+            var offsetSeconds = offsetTime.Offset.Seconds;
+
+            Expression newLocalTimeExpr = null;
+            if (offsetTime.NanosecondOfSecond != 0)
+                newLocalTimeExpr = ConstantCall(_localTimeFactoryMethodInfo, offsetTime.Hour, offsetTime.Minute, offsetTime.Second, (long)offsetTime.NanosecondOfSecond);
+            else if (offsetTime.Second != 0)
+                newLocalTimeExpr = ConstantNew(_localTimeCtorInfo2, offsetTime.Hour, offsetTime.Minute, offsetTime.Second);
+            else
+                newLocalTimeExpr = ConstantNew(_localTimeCtorInfo1, offsetTime.Hour, offsetTime.Minute);
+
+            return Expression.New(_ctorInfo,
+                newLocalTimeExpr,
+                offsetSeconds % 3600 == 0
+                    ? ConstantCall(_offsetFactoryMethodInfo1, offsetSeconds / 3600)
+                    : ConstantCall(_offsetFactoryMethodInfo2, offsetSeconds));
+        }
     }
 
     #endregion timetz
@@ -188,6 +317,10 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
 
         protected override string GenerateNonNullSqlLiteral(object value)
             => $"INTERVAL '{PeriodPattern.NormalizingIso.Format((Period)value)}'";
+
+        // GenerateCodeLiteral isn't implemented because round-tripping Period would require either using the plus operator
+        // to compose the components (years + months...), or setting properties on PeriodBuilder, neither of which is
+        // currently supported by EF Core's code generator
     }
 
     #endregion interval

--- a/src/EFCore.PG.NodaTime/Utilties/Util.cs
+++ b/src/EFCore.PG.NodaTime/Utilties/Util.cs
@@ -1,0 +1,15 @@
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime.Utilties
+{
+    static class Util
+    {
+        internal static NewExpression ConstantNew(ConstructorInfo constructor, params object[] parameters)
+            => Expression.New(constructor, parameters.Select(p => Expression.Constant(p)).ToArray());
+
+        internal static MethodCallExpression ConstantCall(MethodInfo method, params object[] parameters)
+            => Expression.Call(method, parameters.Select(p => Expression.Constant(p)).ToArray());
+    }
+}

--- a/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlTypeMapping.cs
+++ b/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlTypeMapping.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Data.Common;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -15,7 +15,6 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
         /// The database type used by Npgsql.
         /// </summary>
         public NpgsqlDbType NpgsqlDbType { get; }
-
         // ReSharper disable once PublicConstructorInAbstractClass
         /// <summary>
         /// Constructs an instance of the <see cref="NpgsqlTypeMapping"/> class.
@@ -23,10 +22,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
         /// <param name="storeType">The database type to map.</param>
         /// <param name="clrType">The CLR type to map.</param>
         /// <param name="npgsqlDbType">The database type used by Npgsql.</param>
-        public NpgsqlTypeMapping(
-            [NotNull] string storeType,
-            [NotNull] Type clrType,
-            NpgsqlDbType npgsqlDbType)
+        public NpgsqlTypeMapping([NotNull] string storeType, [NotNull] Type clrType, NpgsqlDbType npgsqlDbType)
             : base(storeType, clrType)
             => NpgsqlDbType = npgsqlDbType;
 

--- a/test/EFCore.PG.Plugins.FunctionalTests/EFCore.PG.Plugins.FunctionalTests.csproj
+++ b/test/EFCore.PG.Plugins.FunctionalTests/EFCore.PG.Plugins.FunctionalTests.csproj
@@ -19,4 +19,7 @@
     <ProjectReference Include="..\..\src\EFCore.PG.NTS\EFCore.PG.NTS.csproj" />
     <ProjectReference Include="..\EFCore.PG.FunctionalTests\EFCore.PG.FunctionalTests.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="$(EFCoreVersion)" />
+  </ItemGroup>
 </Project>

--- a/test/EFCore.PG.Plugins.FunctionalTests/NpgsqlNodaTimeTypeMappingTest.cs
+++ b/test/EFCore.PG.Plugins.FunctionalTests/NpgsqlNodaTimeTypeMappingTest.cs
@@ -1,7 +1,11 @@
 using System;
+using Microsoft.EntityFrameworkCore.Design.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
+using NodaTime.Calendars;
 using NodaTime.TimeZones;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Internal;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal;
 using Xunit;
 
@@ -27,6 +31,16 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL
 
             var localDateTime = new LocalDateTime(2018, 4, 20, 10, 31, 33, 666) + Period.FromTicks(6660);
             Assert.Equal("TIMESTAMP '2018-04-20T10:31:33.666666'", mapping.GenerateSqlLiteral(localDateTime));
+        }
+
+        [Fact]
+        public void GenerateCodeLiteral_returns_local_date_time_literal()
+        {
+            Assert.Equal("new NodaTime.LocalDateTime(2018, 4, 20, 10, 31)", CodeLiteral(new LocalDateTime(2018, 4, 20, 10, 31)));
+            Assert.Equal("new NodaTime.LocalDateTime(2018, 4, 20, 10, 31, 33)", CodeLiteral(new LocalDateTime(2018, 4, 20, 10, 31, 33)));
+
+            var localDateTime = new LocalDateTime(2018, 4, 20, 10, 31, 33) + Period.FromNanoseconds(1);
+            Assert.Equal("new NodaTime.LocalDateTime(2018, 4, 20, 10, 31, 33).PlusNanoseconds(1L)", CodeLiteral(localDateTime));
         }
 
         [Fact]
@@ -64,11 +78,31 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL
         }
 
         [Fact]
+        public void GenerateCodeLiteral_returns_offset_date_time_literal()
+        {
+            Assert.Equal("new NodaTime.OffsetDateTime(new NodaTime.LocalDateTime(2018, 4, 20, 10, 31), NodaTime.Offset.FromHours(-2))",
+                CodeLiteral(new OffsetDateTime(new LocalDateTime(2018, 4, 20, 10, 31), Offset.FromHours(-2))));
+
+            Assert.Equal("new NodaTime.OffsetDateTime(new NodaTime.LocalDateTime(2018, 4, 20, 10, 31, 33), NodaTime.Offset.FromSeconds(9000))",
+                CodeLiteral(new OffsetDateTime(new LocalDateTime(2018, 4, 20, 10, 31, 33), Offset.FromHoursAndMinutes(2, 30))));
+
+            Assert.Equal("new NodaTime.OffsetDateTime(new NodaTime.LocalDateTime(2018, 4, 20, 10, 31, 33), NodaTime.Offset.FromSeconds(-1))",
+                CodeLiteral(new OffsetDateTime(new LocalDateTime(2018, 4, 20, 10, 31, 33), Offset.FromSeconds(-1))));
+        }
+
+        [Fact]
         public void GenerateSqlLiteral_returns_local_date_literal()
         {
             var mapping = GetMapping(typeof(LocalDate));
 
             Assert.Equal("DATE '2018-04-20'", mapping.GenerateSqlLiteral(new LocalDate(2018, 4, 20)));
+        }
+
+        [Fact]
+        public void GenerateCodeLiteral_returns_local_date_literal()
+        {
+            Assert.Equal("new NodaTime.LocalDate(2018, 4, 20)", CodeLiteral(new LocalDate(2018, 4, 20)));
+            Assert.Equal("new NodaTime.LocalDate(-2017, 4, 20)", CodeLiteral(new LocalDate(Era.BeforeCommon, 2018, 4, 20)));
         }
 
         [Fact]
@@ -79,6 +113,15 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL
             Assert.Equal("TIME '10:31:33'", mapping.GenerateSqlLiteral(new LocalTime(10, 31, 33)));
             Assert.Equal("TIME '10:31:33.666'", mapping.GenerateSqlLiteral(new LocalTime(10, 31, 33, 666)));
             Assert.Equal("TIME '10:31:33.666666'", mapping.GenerateSqlLiteral(new LocalTime(10, 31, 33, 666) + Period.FromTicks(6660)));
+        }
+
+        [Fact]
+        public void GenerateCodeLiteral_returns_local_time_literal()
+        {
+            Assert.Equal("new NodaTime.LocalTime(9, 30)", CodeLiteral(new LocalTime(9, 30)));
+            Assert.Equal("new NodaTime.LocalTime(9, 30, 15)", CodeLiteral(new LocalTime(9, 30, 15)));
+            Assert.Equal("NodaTime.LocalTime.FromHourMinuteSecondNanosecond(9, 30, 15, 500000000L)", CodeLiteral(new LocalTime(9, 30, 15, 500)));
+            Assert.Equal("NodaTime.LocalTime.FromHourMinuteSecondNanosecond(9, 30, 15, 1L)", CodeLiteral(LocalTime.FromHourMinuteSecondNanosecond(9, 30, 15, 1)));
         }
 
         [Fact]
@@ -93,6 +136,11 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL
             Assert.Equal("TIMETZ '10:31:33.666666Z'", mapping.GenerateSqlLiteral(
                 new OffsetTime(new LocalTime(10, 31, 33, 666) + Period.FromTicks(6660), Offset.Zero)));
         }
+
+        [Fact]
+        public void GenerateCodeLiteral_returns_offset_time_literal()
+            => Assert.Equal("new NodaTime.OffsetTime(new NodaTime.LocalTime(10, 31, 33), NodaTime.Offset.FromHours(2))",
+                CodeLiteral(new OffsetTime(new LocalTime(10, 31, 33), Offset.FromHours(2))));
 
         [Fact]
         public void GenerateSqlLiteral_returns_period_literal()
@@ -114,14 +162,28 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL
 
         #region Support
 
-        static readonly IRelationalTypeMappingSourcePlugin Mapper =
-            new NpgsqlNodaTimeTypeMappingSourcePlugin(new NpgsqlSqlGenerationHelper(new RelationalSqlGenerationHelperDependencies()));
+        static readonly NpgsqlTypeMappingSource Mapper = new NpgsqlTypeMappingSource(
+            new TypeMappingSourceDependencies(
+                new ValueConverterSelector(new ValueConverterSelectorDependencies()),
+                Array.Empty<ITypeMappingSourcePlugin>()),
+            new RelationalTypeMappingSourceDependencies(
+                new IRelationalTypeMappingSourcePlugin[] {
+                    new NpgsqlNodaTimeTypeMappingSourcePlugin(new NpgsqlSqlGenerationHelper(new RelationalSqlGenerationHelperDependencies()))
+                }),
+            new NpgsqlSqlGenerationHelper(new RelationalSqlGenerationHelperDependencies()),
+            new NpgsqlOptions()
+        );
 
-        static RelationalTypeMapping GetMapping(Type clrType)
-            => Mapper.FindMapping(new RelationalTypeMappingInfo(clrType));
+        static RelationalTypeMapping GetMapping(string storeType) => Mapper.FindMapping(storeType);
+
+        static RelationalTypeMapping GetMapping(Type clrType) => (RelationalTypeMapping)Mapper.FindMapping(clrType);
 
         static RelationalTypeMapping GetMapping(Type clrType, string storeType)
-            => Mapper.FindMapping(new RelationalTypeMappingInfo(clrType, storeType, storeType, false, null, null, null, null, null, null));
+            => Mapper.FindMapping(clrType, storeType);
+
+        static readonly CSharpHelper CsHelper = new CSharpHelper(Mapper);
+
+        static string CodeLiteral(object value) => CsHelper.UnknownLiteral(value);
 
         #endregion Support
     }


### PR DESCRIPTION
Not done: Instant, ZonedDateTime and Period, which require features not yet supported by the EF Core code generator.

This PR is meant to be backported to 2.2.x. I'll try to work on code generation improvements in EF Core to enable the rest of the types for 3.0.

Closes #713 