### PR TITLE
Corrects the name in the doc of the full-text-search-trigger to drop

### DIFF
--- a/doc/mapping/full-text-search.md
+++ b/doc/mapping/full-text-search.md
@@ -116,7 +116,7 @@ public partial class CreateProductTable : Migration
     protected override void Down(MigrationBuilder migrationBuilder)
     {
         // Migrations for dropping of the column and the index will appear here, all we need to do is drop the trigger:
-        migrationBuilder.Sql("DROP TRIGGER product_search_vector");
+        migrationBuilder.Sql("DROP TRIGGER product_search_vector_update");
     }
 }
 ```


### PR DESCRIPTION
The trigger name which gets generated (`product_search_vector_update`):

``` csharp
migrationBuilder.Sql(
            @"CREATE TRIGGER product_search_vector_update BEFORE INSERT OR UPDATE
              ON ""Products"" FOR EACH ROW EXECUTE PROCEDURE
              tsvector_update_trigger(""SearchVector"", 'pg_catalog.english', ""Name"", ""Description"");");
```

should match the one being deleted:

``` csharp
migrationBuilder.Sql("DROP TRIGGER product_search_vector_update");
```

instead of:

``` csharp
migrationBuilder.Sql("DROP TRIGGER product_search_vector");
```