### PR TITLE
Add support for PGroonga.EntityFrameworkCore EF.Functions

### DIFF
--- a/src/EFCore.PG/Query/EvaluatableExpressionFilters/Internal/NpgsqlCompositeEvaluatableExpressionFilter.cs
+++ b/src/EFCore.PG/Query/EvaluatableExpressionFilters/Internal/NpgsqlCompositeEvaluatableExpressionFilter.cs
@@ -23,7 +23,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.EvaluatableExpressionFilte
             new List<IEvaluatableExpressionFilter>
             {
                 new NpgsqlFullTextSearchEvaluatableExpressionFilter(),
-                new NpgsqlNodaTimeEvaluatableExpressionFilter()
+                new NpgsqlNodaTimeEvaluatableExpressionFilter(),
+                new NpgsqlPGroongaEvaluatableExpressionFilter()
             };
 
         /// <inheritdoc />

--- a/src/EFCore.PG/Query/EvaluatableExpressionFilters/Internal/NpgsqlPGroongaEvaluatableExpressionFilter.cs
+++ b/src/EFCore.PG/Query/EvaluatableExpressionFilters/Internal/NpgsqlPGroongaEvaluatableExpressionFilter.cs
@@ -1,0 +1,46 @@
+﻿#region License
+
+// The PostgreSQL License
+//
+// Copyright (C) 2016 The Npgsql Development Team
+//
+// Permission to use, copy, modify, and distribute this software and its
+// documentation for any purpose, without fee, and without a written
+// agreement is hereby granted, provided that the above copyright notice
+// and this paragraph and the following two paragraphs appear in all copies.
+//
+// IN NO EVENT SHALL THE NPGSQL DEVELOPMENT TEAM BE LIABLE TO ANY PARTY
+// FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES,
+// INCLUDING LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS
+// DOCUMENTATION, EVEN IF THE NPGSQL DEVELOPMENT TEAM HAS BEEN ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//
+// THE NPGSQL DEVELOPMENT TEAM SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS
+// ON AN "AS IS" BASIS, AND THE NPGSQL DEVELOPMENT TEAM HAS NO OBLIGATIONS
+// TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+
+#endregion
+
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Query.Internal;
+
+// Note: EvaluatableExpressionFilterBase will be disappearing in 3.0, at least in its current form
+#pragma warning disable EF1001
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.EvaluatableExpressionFilters.Internal
+{
+    // TODO: This is a hack until https://github.com/aspnet/EntityFrameworkCore/issues/13454 is done
+    public class NpgsqlPGroongaEvaluatableExpressionFilter : EvaluatableExpressionFilterBase
+    {
+        /// <inheritdoc />
+        public override bool IsEvaluatableExpression(Expression expression)
+            => !(
+                (expression is MethodCallExpression methodExpr &&
+                methodExpr.Method.DeclaringType?.FullName == "Microsoft.EntityFrameworkCore.PGroongaDbFunctionsExtensions")
+                ||
+                (expression is MemberExpression memberExpr &&
+                memberExpr.Member.DeclaringType?.FullName == "Microsoft.EntityFrameworkCore.PGroongaDbFunctionsExtensions"));
+    }
+}


### PR DESCRIPTION
(related to #243, and #726)

The EF.Functions for PGroonga functions has been implemented at JoyMoe/PGroonga.EntityFrameworkCore@cc975ddfbe964f71629a37be214a0be3fa2a5ae2, but due to aspnet/EntityFrameworkCore#13454 we should add an evaluatable filter here.

There's also a backport for 2.x at #910.