### PR TITLE
Add support for ProvidePasswordCallback to EFCore.PG

### DIFF
--- a/src/EFCore.PG/Infrastructure/Internal/NpgsqlOptionsExtension.cs
+++ b/src/EFCore.PG/Infrastructure/Internal/NpgsqlOptionsExtension.cs
@@ -51,6 +51,12 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal
         public RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get; private set; }
 
         /// <summary>
+        /// The specified <see cref="ProvidePasswordCallback"/>.
+        /// </summary>
+        [CanBeNull]
+        public ProvidePasswordCallback ProvidePasswordCallback { get; private set; }
+
+        /// <summary>
         /// True if reverse null ordering is enabled; otherwise, false.
         /// </summary>
         public bool ReverseNullOrdering { get; private set; }
@@ -73,6 +79,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal
             PostgresVersion = copyFrom.PostgresVersion;
             ProvideClientCertificatesCallback = copyFrom.ProvideClientCertificatesCallback;
             RemoteCertificateValidationCallback = copyFrom.RemoteCertificateValidationCallback;
+            ProvidePasswordCallback = copyFrom.ProvidePasswordCallback;
             ReverseNullOrdering = copyFrom.ReverseNullOrdering;
         }
 
@@ -185,6 +192,20 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal
             return clone;
         }
 
+        /// <summary>
+        /// Returns a copy of the current instance with the specified <see cref="ProvidePasswordCallback"/>.
+        /// </summary>
+        /// <param name="callback">The specified callback.</param>
+        [NotNull]
+        public virtual NpgsqlOptionsExtension WithProvidePasswordCallback([CanBeNull] ProvidePasswordCallback callback)
+        {
+            var clone = (NpgsqlOptionsExtension)Clone();
+
+            clone.ProvidePasswordCallback = callback;
+
+            return clone;
+        }
+
         #endregion Authentication
 
         #region Infrastructure
@@ -245,6 +266,11 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal
                         builder.Append("RemoteCertificateValidationCallback ");
                     }
 
+                    if (Extension.ProvidePasswordCallback != null)
+                    {
+                        builder.Append("ProvidePasswordCallback ");
+                    }
+
                     if (Extension.ReverseNullOrdering)
                     {
                         builder.Append("ReverseNullOrdering ");
@@ -289,6 +315,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal
                         _serviceProviderHash = (_serviceProviderHash * 397) ^ (Extension.PostgresVersion?.GetHashCode() ?? 0L);
                         _serviceProviderHash = (_serviceProviderHash * 397) ^ (Extension.ProvideClientCertificatesCallback?.GetHashCode() ?? 0L);
                         _serviceProviderHash = (_serviceProviderHash * 397) ^ (Extension.RemoteCertificateValidationCallback?.GetHashCode() ?? 0L);
+                        _serviceProviderHash = (_serviceProviderHash * 397) ^ (Extension.ProvidePasswordCallback?.GetHashCode() ?? 0L);
                         _serviceProviderHash = (_serviceProviderHash * 397) ^ Extension.ReverseNullOrdering.GetHashCode();
                     }
 
@@ -313,6 +340,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal
 
                 debugInfo["Npgsql.EntityFrameworkCore.PostgreSQL:" + nameof(NpgsqlDbContextOptionsBuilder.ProvideClientCertificatesCallback)]
                     = (Extension.ProvideClientCertificatesCallback?.GetHashCode() ?? 0).ToString(CultureInfo.InvariantCulture);
+                
+                debugInfo["Npgsql.EntityFrameworkCore.PostgreSQL:" + nameof(NpgsqlDbContextOptionsBuilder.ProvidePasswordCallback)]
+                    = (Extension.ProvidePasswordCallback?.GetHashCode() ?? 0).ToString(CultureInfo.InvariantCulture);
 
                 foreach (var rangeDefinition in Extension._userRangeDefinitions)
                 {

--- a/src/EFCore.PG/Infrastructure/Internal/NpgsqlOptionsExtension.cs
+++ b/src/EFCore.PG/Infrastructure/Internal/NpgsqlOptionsExtension.cs
@@ -248,37 +248,37 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal
 
                     if (Extension.AdminDatabase != null)
                     {
-                        builder.Append("AdminDatabase=").Append(Extension.AdminDatabase).Append(' ');
+                        builder.Append(nameof(Extension.AdminDatabase)).Append("=").Append(Extension.AdminDatabase).Append(' ');
                     }
 
                     if (Extension.PostgresVersion != null)
                     {
-                        builder.Append("PostgresVersion=").Append(Extension.PostgresVersion).Append(' ');
+                        builder.Append(nameof(Extension.PostgresVersion)).Append("=").Append(Extension.PostgresVersion).Append(' ');
                     }
 
                     if (Extension.ProvideClientCertificatesCallback != null)
                     {
-                        builder.Append("ProvideClientCertificatesCallback ");
+                        builder.Append(nameof(Extension.ProvideClientCertificatesCallback)).Append(" ");
                     }
 
                     if (Extension.RemoteCertificateValidationCallback != null)
                     {
-                        builder.Append("RemoteCertificateValidationCallback ");
+                        builder.Append(nameof(Extension.RemoteCertificateValidationCallback)).Append(" ");
                     }
 
                     if (Extension.ProvidePasswordCallback != null)
                     {
-                        builder.Append("ProvidePasswordCallback ");
+                        builder.Append(nameof(Extension.ProvidePasswordCallback)).Append(" ");
                     }
 
                     if (Extension.ReverseNullOrdering)
                     {
-                        builder.Append("ReverseNullOrdering ");
+                        builder.Append(nameof(Extension.ReverseNullOrdering)).Append(" ");;
                     }
 
                     if (Extension.UserRangeDefinitions.Count > 0)
                     {
-                        builder.Append("UserRangeDefinitions=[");
+                        builder.Append(nameof(Extension.UserRangeDefinitions)).Append("=[");
                         foreach (var item in Extension.UserRangeDefinitions)
                         {
                             builder.Append(item.SubtypeClrType).Append("=>");

--- a/src/EFCore.PG/Infrastructure/NpgsqlDbContextOptionsBuilder.cs
+++ b/src/EFCore.PG/Infrastructure/NpgsqlDbContextOptionsBuilder.cs
@@ -110,6 +110,13 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure
         public virtual void RemoteCertificateValidationCallback([CanBeNull] RemoteCertificateValidationCallback callback)
             => WithOption(e => e.WithRemoteCertificateValidationCallback(callback));
 
+        /// <summary>
+        /// Configures the <see cref="DbContext"/> to use the specified <see cref="ProvidePasswordCallback"/>.
+        /// </summary>
+        /// <param name="callback">The callback to use.</param>
+        public virtual void ProvidePasswordCallback([CanBeNull] ProvidePasswordCallback callback)
+            => WithOption(e => e.WithProvidePasswordCallback(callback));
+
         #endregion Authentication
 
         #region Retrying execution strategy

--- a/src/EFCore.PG/Storage/Internal/NpgsqlRelationalConnection.cs
+++ b/src/EFCore.PG/Storage/Internal/NpgsqlRelationalConnection.cs
@@ -12,6 +12,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
     {
         ProvideClientCertificatesCallback ProvideClientCertificatesCallback { get; }
         RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get; }
+        ProvidePasswordCallback ProvidePasswordCallback { get; }
+
 
         /// <summary>
         ///     Indicates whether the store connection supports ambient transactions
@@ -26,6 +28,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
 
             ProvideClientCertificatesCallback = npgsqlOptions.ProvideClientCertificatesCallback;
             RemoteCertificateValidationCallback = npgsqlOptions.RemoteCertificateValidationCallback;
+            ProvidePasswordCallback = npgsqlOptions.ProvidePasswordCallback;
         }
 
         protected override DbConnection CreateDbConnection()
@@ -35,6 +38,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
                 conn.ProvideClientCertificatesCallback = ProvideClientCertificatesCallback;
             if (RemoteCertificateValidationCallback != null)
                 conn.UserCertificateValidationCallback = RemoteCertificateValidationCallback;
+            if (ProvidePasswordCallback != null)
+                conn.ProvidePasswordCallback = ProvidePasswordCallback;
             return conn;
         }
 

--- a/test/EFCore.PG.FunctionalTests/LoggingNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/LoggingNpgsqlTest.cs
@@ -39,6 +39,15 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL
         }
 
         [Fact]
+        public void Logs_context_initialization_provide_password_callback()
+        {
+            ProvidePasswordCallback passwordCallback = (h,p,d,u) => "password";
+            Assert.Equal(
+                ExpectedMessage($"ProvidePasswordCallback " + DefaultOptions),
+                ActualMessage(s => CreateOptionsBuilder(s, b => ((NpgsqlDbContextOptionsBuilder)b).ProvidePasswordCallback(passwordCallback))));
+        }
+
+        [Fact]
         public void Logs_context_initialization_remote_certificate_validation_callback()
         {
             RemoteCertificateValidationCallback testCallback = (sender, certificate, chain, sslPolicyErrors) => true;


### PR DESCRIPTION
This repo has not been updated to use a new enough version (>4.1) of Npgsql yet for this to compile. I didn't want to charge ahead and do that as it seems outside the scope of this PR to do that upgrade, but it is required for this PR as it uses the new member `ProvidePasswordCallback` on `NpgsqlConnection` which was added in https://github.com/npgsql/npgsql/pull/2502

