### PR TITLE
Add semicolon and condition for schema statement to 2.1.x

### DIFF
--- a/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
@@ -987,7 +987,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations
                 .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(name, schema))
                 .Append(" SET SCHEMA ")
                 .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(newSchema))
-                .AppendLine(';');
+                .AppendLine(Dependencies.SqlGenerationHelper.StatementTerminator);
         }
 
         #endregion Utilities

--- a/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
@@ -957,7 +957,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations
                 .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(name, schema))
                 .Append(" RENAME TO ")
                 .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(newName))
-                .AppendLine(';');
+                .AppendLine(Dependencies.SqlGenerationHelper.StatementTerminator);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #921 by applying changes from #701.

Tried to cherry-pick `266aa00279c88c8e568a48e5936bfb962f21ced7`, conflicts needed to be fixed.

@austindrenski force-pushing to the same branch automatically closed the other PR (https://github.com/npgsql/Npgsql.EntityFrameworkCore.PostgreSQL/pull/922)
