### PR TITLE
Update azure-pipelines.yml

### DIFF
--- a/.build/setup_postgres.ps1
+++ b/.build/setup_postgres.ps1
@@ -2,9 +2,11 @@
 powershell -c "Invoke-Expression ((New-Object Net.WebClient).DownloadString('https://s3.amazonaws.com/pgcentral/install.ps1'))";
 
 # Install PostgreSQL
+bigsql/pgc list
 bigsql/pgc install pg11
 
 # Install PostGIS
+bigsql/pgc list --extensions pg11
 bigsql/pgc install postgis25-pg11
 
 # Start PostgreSQL

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,27 +1,32 @@
 name: 3.0.0-ci.$(Date:yyyyMMdd).$(Rev:r) # equal to $(Build.BuildNumber)
-trigger:
-  branches:
-    include:
-    - dev
-    - master
-    - hotfix/*
-    - release/*
+
 variables:
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
-  DOTNET_SDK_VERSION: '3.0.100-preview3-010431'
+  DOTNET_SDK_VERSION: '3.0.100-preview5-011568'
+
 jobs:
+
 - job: Linux
+
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: 'ubuntu-16.04'
+
   steps:
+  - bash: |
+      export TRUNCATED_SHA1=${BUILD_SOURCEVERSION:0:9}
+      echo "##vso[task.setvariable variable=truncated_sha1]$TRUNCATED_SHA1";
+    displayName: 'Assign truncated SHA1 to environment variable'
+
   - bash: sudo sh .build/setup_postgres.sh
     displayName: 'Start PostgreSQL'
-  - task: DotNetCoreInstaller@0
+
+  - task: DotNetCoreInstaller@1
     displayName: 'Install .NET Core SDK'
     inputs:
       packageType: 'sdk'
       version: '$(DOTNET_SDK_VERSION)'
+
   - task: DotNetCoreCLI@2
     displayName: 'Test'
     inputs:
@@ -29,19 +34,50 @@ jobs:
       configuration: 'Debug'
       projects: 'test/**/*.csproj'
       publishTestResults: true
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Pack Nuget packages'
+    inputs:
+      buildProperties: 'Version=$(Build.BuildNumber)+sha.$(truncated_sha1)'
+      command: 'pack'
+      configuration: 'Release'
+      includeSymbols: false
+      outputDir: '$(Build.ArtifactStagingDirectory)'
+      packagesToPack: 'src/**/*.csproj'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Pack symbol packages'
+    inputs:
+      buildProperties: 'Version=$(Build.BuildNumber)+sha.$(truncated_sha1)'
+      command: 'pack'
+      configuration: 'Release'
+      includeSymbols: true
+      outputDir: '$(Build.ArtifactStagingDirectory)'
+      packagesToPack: 'src/**/*.csproj'
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish artifacts'
+    inputs:
+      pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+      artifactName: 'linux-build'
+
 - job: Windows
   pool:
-    vmImage: vs2017-win2016
+    vmImage: 'vs2017-win2016'
+
   steps:
   - powershell: Write-Host "##vso[task.setvariable variable=truncated_sha1]$($env:BUILD_SOURCEVERSION.subString(0, 9))";
     displayName: 'Assign truncated SHA1 to environment variable'
+
   - powershell: .build/setup_postgres.ps1
     displayName: 'Start PostgreSQL'
-  - task: DotNetCoreInstaller@0
+
+  - task: DotNetCoreInstaller@1
     displayName: 'Install .NET Core SDK'
     inputs:
       packageType: 'sdk'
       version: '$(DOTNET_SDK_VERSION)'
+
   - task: DotNetCoreCLI@2
     displayName: 'Test'
     inputs:
@@ -49,33 +85,52 @@ jobs:
       configuration: 'Debug'
       projects: 'test/**/*.csproj'
       publishTestResults: true
+
   - task: DotNetCoreCLI@2
-    displayName: 'Package'
+    displayName: 'Pack Nuget packages'
     inputs:
+      buildProperties: 'Version=$(Build.BuildNumber)+sha.$(truncated_sha1)'
       command: 'pack'
       configuration: 'Release'
-      buildProperties: 'Version=$(Build.BuildNumber)+sha.$(truncated_sha1)'
+      includeSymbols: false
+      outputDir: '$(Build.ArtifactStagingDirectory)'
       packagesToPack: 'src/**/*.csproj'
-      packDirectory: '$(System.DefaultWorkingDirectory)'
-      verbosityPack: 'normal'
-  # TODO: needed because DotNetCoreCLI@2 doesn't support authenticated feeds yet.
-  # TODO: see https://github.com/Microsoft/azure-pipelines-tasks/issues/7160
-  - task: NuGetToolInstaller@0
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Pack symbol packages'
+    inputs:
+      buildProperties: 'Version=$(Build.BuildNumber)+sha.$(truncated_sha1)'
+      command: 'pack'
+      configuration: 'Release'
+      includeSymbols: true
+      outputDir: '$(Build.ArtifactStagingDirectory)'
+      packagesToPack: 'src/**/*.csproj'
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish artifacts'
+    inputs:
+      pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+      artifactName: 'windows-build'
+
+  - task: NuGetToolInstaller@1 # TODO: needed because DotNetCoreCLI@2 doesn't support authenticated feeds yet. See: https://github.com/Microsoft/azure-pipelines-tasks/issues/7160
+    displayName: 'Install NuGet CLI'
     inputs:
       versionSpec: '4.3.0'
+
   - task: NuGetCommand@2
     displayName: 'Publish to MyGet (unstable)'
     condition: succeeded()
     inputs:
       command: 'push'
       nuGetFeedType: 'external'
-      packagesToPush: '**/*.nupkg'
-      publishFeedCredentials: 'npgsql-unstable' # TODO: add service connection named 'npgsql-unstable' with url 'https://www.myget.org/F/npgsql-unstable/api/v2/package'
+      packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg;!$(Build.ArtifactStagingDirectory)/**/*.snupkg'
+      publishFeedCredentials: 'npgsql-unstable'
+
   - task: NuGetCommand@2
     displayName: 'Publish to MyGet (stable)'
-    condition: and(succeeded(), startsWith(variables['Build.SourceBranchName'], 'hotfix/'))
+    condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/heads/hotfix/'))
     inputs:
       command: 'push'
       nuGetFeedType: 'external'
-      packagesToPush: '**/*.nupkg'
-      publishFeedCredentials: 'npgsql-stable' # TODO: add service connection named 'npgsql-stable' with url 'https://www.myget.org/F/npgsql/api/v2/package'
+      packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg;!$(Build.ArtifactStagingDirectory)/**/*.snupkg'
+      publishFeedCredentials: 'npgsql-stable'


### PR DESCRIPTION
Follow up to #646.

- ~~Upgrade `vs2017-win2016` to `windows2019`~~ This caused the PostgreSQL installer to hang/fail. Skipping for now since we install everything ourselves anyways.
- Upgrade `DotNetCoreInstaller@0` to `DotNetCoreInstaller@1`
- Upgrade `NuGetToolInstaller@0` to `NuGetToolInstaller@1`
- Upgrade .NET Core version `preview3` to `preview5`
- Add task to publish symbols (`.snupkg`) to MyGet
- Add task to publish artifacts (windows + linux)
- ~~Don't let PR builds publish to `npgsql-stable`~~ PR builds don't have access to secrets (e.g. api keys)
- Ensure all steps have a display name
- Try (and most likely fail) to make YAML easier to read

