### PR TITLE
Ignore legacy symbol package format

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -123,7 +123,7 @@ jobs:
     inputs:
       command: 'push'
       nuGetFeedType: 'external'
-      packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg;!$(Build.ArtifactStagingDirectory)/**/*.snupkg'
+      packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg;!$(Build.ArtifactStagingDirectory)/**/*.symbols.nupkg;!$(Build.ArtifactStagingDirectory)/**/*.snupkg'
       publishFeedCredentials: 'npgsql-unstable'
 
   - task: NuGetCommand@2
@@ -132,5 +132,5 @@ jobs:
     inputs:
       command: 'push'
       nuGetFeedType: 'external'
-      packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg;!$(Build.ArtifactStagingDirectory)/**/*.snupkg'
+      packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg;!$(Build.ArtifactStagingDirectory)/**/*.symbols.nupkg;!$(Build.ArtifactStagingDirectory)/**/*.snupkg'
       publishFeedCredentials: 'npgsql-stable'


### PR DESCRIPTION
The dotnet CLI task produces `*.symbols.nupkg` instead of the newer `.snupkg` format. Ignore both for now.

_Note: since theses tasks don't trigger on PR builds, the issue is only observable after merge._

## Related

#646
#928 
#929 