### PR TITLE
Fix system column filtering in migrations

### DIFF
--- a/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
@@ -65,22 +65,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations
             MigrationCommandListBuilder builder,
             bool terminate)
         {
-            // Filter out any system columns
-            if (operation.Columns.Any(c => IsSystemColumn(c.Name)))
-            {
-                var filteredOperation = new CreateTableOperation
-                {
-                    Name = operation.Name,
-                    Schema = operation.Schema,
-                    PrimaryKey = operation.PrimaryKey,
-                };
-                filteredOperation.Columns.AddRange(operation.Columns.Where(c => !_systemColumnNames.Contains(c.Name)));
-                filteredOperation.ForeignKeys.AddRange(operation.ForeignKeys);
-                filteredOperation.UniqueConstraints.AddRange(operation.UniqueConstraints);
-                operation = filteredOperation;
-            }
-
-            #region Customized base call
+            operation.Columns.RemoveAll(c => IsSystemColumn(c.Name));
 
             builder.Append("CREATE ");
 
@@ -100,8 +85,6 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations
             }
 
             builder.Append(")");
-
-            #endregion
 
             // CockroachDB "interleave in parent" (https://www.cockroachlabs.com/docs/stable/interleave-in-parent.html)
             if (operation[CockroachDbAnnotationNames.InterleaveInParent] is string)


### PR DESCRIPTION
If a system column was present when creating a table, we filtered it out by creating a copy of CreateTableOperation. We didn't copy across all fields, so comments didn't get created.

Switched to the less brutal practice of mutating the operation in place to remove columns instead of creating a copy.

Fixes #834