### PR TITLE
Added functionality for translating JSON operators

### DIFF
--- a/src/EFCore.PG/Extensions/NpgsqlJsonExtensions.cs
+++ b/src/EFCore.PG/Extensions/NpgsqlJsonExtensions.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Runtime.CompilerServices;
+using JetBrains.Annotations;
+using NpgsqlTypes;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore
+{
+    /// <summary>
+    /// Provides extension methods for JSON operators supporting PostgreSQL translation.
+    /// </summary>
+    public static class NpgsqlJsonExtensions
+    {
+        /// <summary>
+        /// Determines whether a JSON object contains a specified key.
+        /// </summary>
+        /// <param name="propertyName">The database column being searched in.</param>
+        /// <param name="jsonKey">The key to locate in json.</param>
+        /// <returns>
+        /// <value>true</value> if the json object contains the specified key; otherwise, <value>false</value>.
+        /// </returns>
+        /// <exception cref="NotSupportedException">{method} is only intended for use via SQL translation as part of an EF Core LINQ query.</exception>
+        public static bool KeyExists(string propertyName, string jsonKey) => throw ClientEvaluationNotSupportedException();
+
+        /// <summary>
+        /// Gets all values related to a specific json key.
+        /// </summary>
+        /// <param name="propertyName">The database column being searched in.</param>
+        /// <param name="jsonKey">The key to locate in json.</param>
+        /// <returns>
+        /// <value>string value</value> return value associated with json key as string.
+        /// </returns>
+        /// <exception cref="NotSupportedException">{method} is only intended for use via SQL translation as part of an EF Core LINQ query.</exception>
+        public static string GetValue(string propertyName, string jsonKey) => throw ClientEvaluationNotSupportedException();
+
+        #region Utilities
+
+        /// <summary>
+        /// Helper method to throw a <see cref="NotSupportedException"/> with the name of the throwing method.
+        /// </summary>
+        /// <param name="method">The method that throws the exception.</param>
+        /// <returns>
+        /// A <see cref="NotSupportedException"/>.
+        /// </returns>
+        [NotNull]
+        static NotSupportedException ClientEvaluationNotSupportedException([CallerMemberName] string method = default)
+            => new NotSupportedException($"{method} is only intended for use via SQL translation as part of an EF Core LINQ query.");
+
+        #endregion
+    }
+}

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlCastTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlCastTranslator.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Internal
+{
+    /// <summary>
+    /// Provides services casting PostgreSQL json queries to correct type.
+    /// </summary>
+    public class NpgsqlCastTranslator : IMethodCallTranslator
+    {
+        [NotNull]
+        readonly ISqlExpressionFactory _sqlExpressionFactory;
+        [NotNull]
+        readonly RelationalTypeMapping _boolMapping;
+
+        public NpgsqlCastTranslator(ISqlExpressionFactory sqlExpressionFactory)
+        {
+            _sqlExpressionFactory = sqlExpressionFactory;
+            _boolMapping = sqlExpressionFactory.FindMapping(typeof(bool));
+        }
+
+        /// <inheritdoc />
+        [CanBeNull]
+        public SqlExpression Translate(SqlExpression instance, MethodInfo method, IReadOnlyList<SqlExpression> arguments)
+        {
+            if (method.IsStatic && method.Name == nameof(double.Parse))
+            {
+                return _sqlExpressionFactory.Convert(
+                    arguments[0],
+                    typeof(double),
+                    _sqlExpressionFactory.FindMapping(typeof(double))
+                );
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlJsonTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlJsonTranslator.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+using Microsoft.EntityFrameworkCore.Storage;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Query.Expressions.Internal;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Internal
+{
+    /// <summary>
+    /// Provides translation services for PostgreSQL json operators.
+    /// </summary>
+    public class NpgsqlJsonTranslator : IMethodCallTranslator
+    {
+        [NotNull]
+        readonly ISqlExpressionFactory _sqlExpressionFactory;
+        [NotNull]
+        readonly RelationalTypeMapping _boolMapping;
+
+        public NpgsqlJsonTranslator(ISqlExpressionFactory sqlExpressionFactory)
+        {
+            _sqlExpressionFactory = sqlExpressionFactory;
+            _boolMapping = sqlExpressionFactory.FindMapping(typeof(bool));
+        }
+
+        /// <inheritdoc />
+        [CanBeNull]
+        public SqlExpression Translate(SqlExpression instance, MethodInfo method, IReadOnlyList<SqlExpression> arguments)
+        {
+            if (method.DeclaringType != typeof(NpgsqlJsonExtensions))
+                return null;
+
+            return method.Name switch
+            {
+                nameof(NpgsqlJsonExtensions.KeyExists) => GetCustomBinaryExpression("?"),
+                nameof(NpgsqlJsonExtensions.GetValue) => GetCustomBinaryExpression("->"),
+
+                _ => null
+            };
+
+            SqlCustomBinaryExpression GetCustomBinaryExpression(string @operator)
+            {
+                var inferredMapping = ExpressionExtensions.InferTypeMapping(arguments[0], arguments[1]);
+                return new SqlCustomBinaryExpression(
+                    _sqlExpressionFactory.ApplyTypeMapping(arguments[0], inferredMapping),
+                    _sqlExpressionFactory.ApplyTypeMapping(arguments[1], inferredMapping),
+                    @operator,
+                    method.ReturnType,
+                    inferredMapping);
+            }
+        }
+    }
+}


### PR DESCRIPTION
As discussed in #965 , created a PR with a first example of my approach.

Added extension methods and translator for translating EF methods to translate the ? and -> PostgreSQL JSON operators.