### PR TITLE
New EF Core comment support (take 2)

### DIFF
--- a/src/EFCore.PG/Design/Internal/NpgsqlAnnotationCodeGenerator.cs
+++ b/src/EFCore.PG/Design/Internal/NpgsqlAnnotationCodeGenerator.cs
@@ -1,12 +1,10 @@
 using System;
 using System.Diagnostics;
-using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
-using Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.Internal;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Utilities;
@@ -129,9 +127,6 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Design.Internal
             Check.NotNull(entityType, nameof(entityType));
             Check.NotNull(annotation, nameof(annotation));
 
-            if (annotation.Name == NpgsqlAnnotationNames.Comment)
-                return new MethodCallCodeFragment(nameof(NpgsqlEntityTypeBuilderExtensions.HasComment), annotation.Value);
-
             if (annotation.Name == NpgsqlAnnotationNames.UnloggedTable)
                 return new MethodCallCodeFragment(nameof(NpgsqlEntityTypeBuilderExtensions.IsUnlogged), annotation.Value);
 
@@ -164,9 +159,6 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Design.Internal
                     identityOptions.MaxValue,
                     identityOptions.IsCyclic ? true : (bool?)null,
                     identityOptions.NumbersToCache == 1 ? null : (long?)identityOptions.NumbersToCache);
-
-            case NpgsqlAnnotationNames.Comment:
-                return new MethodCallCodeFragment(nameof(NpgsqlPropertyBuilderExtensions.HasComment), annotation.Value);
             }
 
             return null;

--- a/src/EFCore.PG/Extensions/NpgsqlEntityTypeBuilderExtensions.cs
+++ b/src/EFCore.PG/Extensions/NpgsqlEntityTypeBuilderExtensions.cs
@@ -130,41 +130,6 @@ namespace Microsoft.EntityFrameworkCore
 
         #endregion Storage parameters
 
-        #region Comment
-
-        /// <summary>
-        ///     Configures the comment set on the table when targeting Npgsql.
-        /// </summary>
-        /// <param name="entityTypeBuilder"> The builder for the entity type being configured. </param>
-        /// <param name="comment"> The name of the table. </param>
-        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
-        public static EntityTypeBuilder HasComment(
-            [NotNull] this EntityTypeBuilder entityTypeBuilder,
-            [CanBeNull] string comment)
-        {
-            Check.NotNull(entityTypeBuilder, nameof(entityTypeBuilder));
-            Check.NullButNotEmpty(comment, nameof(comment));
-
-            NpgsqlEntityTypeExtensions.SetComment(entityTypeBuilder.Metadata, comment);
-
-            return entityTypeBuilder;
-        }
-
-        /// <summary>
-        ///     Configures the comment set on the table when targeting Npgsql.
-        /// </summary>
-        /// <typeparam name="TEntity"> The entity type being configured. </typeparam>
-        /// <param name="entityTypeBuilder"> The builder for the entity type being configured. </param>
-        /// <param name="comment"> The name of the table. </param>
-        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
-        public static EntityTypeBuilder<TEntity> HasComment<TEntity>(
-            [NotNull] this EntityTypeBuilder<TEntity> entityTypeBuilder,
-            [CanBeNull] string comment)
-            where TEntity : class
-        => (EntityTypeBuilder<TEntity>)HasComment((EntityTypeBuilder)entityTypeBuilder, comment);
-
-        #endregion Comment
-
         #region Unlogged Table
 
         /// <summary>
@@ -290,6 +255,40 @@ namespace Microsoft.EntityFrameworkCore
         #endregion CockroachDB Interleave-in-parent
 
         #region Obsolete
+
+
+        /// <summary>
+        /// Configures a comment to be applied on the table.
+        /// </summary>
+        /// <param name="entityTypeBuilder">The builder for the entity type being configured.</param>
+        /// <param name="comment">The comment for the table.</param>
+        /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+        [Obsolete("Use HasComment")]
+        public static EntityTypeBuilder ForNpgsqlHasComment(
+            [NotNull] this EntityTypeBuilder entityTypeBuilder,
+            [CanBeNull] string comment)
+        {
+            Check.NotNull(entityTypeBuilder, nameof(entityTypeBuilder));
+            Check.NullButNotEmpty(comment, nameof(comment));
+
+            entityTypeBuilder.HasComment(comment);
+
+            return entityTypeBuilder;
+        }
+
+        /// <summary>
+        /// Configures a comment to be applied on the table.
+        /// </summary>
+        /// <typeparam name="TEntity">The entity type being configured.</typeparam>
+        /// <param name="entityTypeBuilder">The builder for the entity type being configured.</param>
+        /// <param name="comment">The comment for the table.</param>
+        /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+        [Obsolete("Use HasComment")]
+        public static EntityTypeBuilder<TEntity> ForNpgsqlHasComment<TEntity>(
+            [NotNull] this EntityTypeBuilder<TEntity> entityTypeBuilder,
+            [CanBeNull] string comment)
+            where TEntity : class
+            => (EntityTypeBuilder<TEntity>)ForNpgsqlHasComment((EntityTypeBuilder)entityTypeBuilder, comment);
 
         /// <summary>
         /// Configures using the auto-updating system column <c>xmin</c> as the optimistic concurrency token.

--- a/src/EFCore.PG/Extensions/NpgsqlEntityTypeExtensions.cs
+++ b/src/EFCore.PG/Extensions/NpgsqlEntityTypeExtensions.cs
@@ -30,12 +30,6 @@ namespace Microsoft.EntityFrameworkCore
         public static void SetStorageParameter([NotNull] this IConventionEntityType entityType, string parameterName, object parameterValue, bool fromDataAnnotation = false)
             => entityType.SetOrRemoveAnnotation(NpgsqlAnnotationNames.StorageParameterPrefix + parameterName, parameterValue, fromDataAnnotation);
 
-        public static string GetComment([NotNull] this IEntityType entityType)
-            => (string)entityType[NpgsqlAnnotationNames.Comment];
-
-        public static void SetComment([NotNull] this IMutableEntityType entityType, [CanBeNull] string comment)
-            => entityType.SetOrRemoveAnnotation(NpgsqlAnnotationNames.Comment, comment);
-
         public static bool GetIsUnlogged([NotNull] this IEntityType entityType)
             => entityType[NpgsqlAnnotationNames.UnloggedTable] as bool? ?? false;
 

--- a/src/EFCore.PG/Extensions/NpgsqlPropertyBuilderExtensions.cs
+++ b/src/EFCore.PG/Extensions/NpgsqlPropertyBuilderExtensions.cs
@@ -612,40 +612,39 @@ namespace Microsoft.EntityFrameworkCore
 
         #endregion Identity options
 
-        #region Comment
+        #region Obsolete
 
         /// <summary>
-        /// Configures the comment set on the column when targeting Npgsql.
+        /// Configures a comment to be applied to the column.
         /// </summary>
-        /// <param name="propertyBuilder"> The builder for the property being configured.</param>
-        /// <param name="comment"> The comment of the column.</param>
+        /// <param name="propertyBuilder">The builder for the property being configured.</param>
+        /// <param name="comment">The comment for the column.</param>
         /// <returns>The same builder instance so that multiple calls can be chained.</returns>
-        public static PropertyBuilder HasComment(
+        [Obsolete("Use HasComment")]
+        public static PropertyBuilder ForNpgsqlHasComment(
             [NotNull] this PropertyBuilder propertyBuilder,
             [CanBeNull] string comment)
         {
             Check.NotNull(propertyBuilder, nameof(propertyBuilder));
             Check.NullButNotEmpty(comment, nameof(comment));
 
-            NpgsqlPropertyExtensions.SetComment(propertyBuilder.Metadata, comment);
+            propertyBuilder.HasComment(comment);
 
             return propertyBuilder;
         }
 
         /// <summary>
-        /// Configures the comment set on the column when targeting Npgsql.
+        /// Configures a comment to be applied to the column.
         /// </summary>
-        /// <param name="propertyBuilder"> The builder for the property being configured.</param>
-        /// <param name="comment"> The comment of the column.</param>
+        /// <typeparam name="TEntity">The entity type being configured.</typeparam>
+        /// <param name="propertyBuilder">The builder for the property being configured.</param>
+        /// <param name="comment">The comment for the column.</param>
         /// <returns>The same builder instance so that multiple calls can be chained.</returns>
-        public static PropertyBuilder<TEntity> HasComment<TEntity>(
+        [Obsolete("Use HasComment")]
+        public static PropertyBuilder<TEntity> ForNpgsqlHasComment<TEntity>(
             [NotNull] this PropertyBuilder<TEntity> propertyBuilder,
             [CanBeNull] string comment)
-        => (PropertyBuilder<TEntity>)HasComment((PropertyBuilder)propertyBuilder, comment);
-
-        #endregion Comment
-
-        #region Obsolete
+            => (PropertyBuilder<TEntity>)ForNpgsqlHasComment((PropertyBuilder)propertyBuilder, comment);
 
         /// <summary>
         /// Configures the property to use a sequence-based hi-lo pattern to generate values for new entities,

--- a/src/EFCore.PG/Extensions/NpgsqlPropertyExtensions.cs
+++ b/src/EFCore.PG/Extensions/NpgsqlPropertyExtensions.cs
@@ -477,15 +477,5 @@ namespace Microsoft.EntityFrameworkCore
             => property.RemoveAnnotation(NpgsqlAnnotationNames.IdentityOptions);
 
         #endregion Identity sequence options
-
-        #region Comment
-
-        public static string GetComment([NotNull] this IProperty property)
-            => (string)property[NpgsqlAnnotationNames.Comment];
-
-        public static void SetComment([NotNull] this IMutableProperty property, [CanBeNull] string comment)
-            => property.SetOrRemoveAnnotation(NpgsqlAnnotationNames.Comment, comment);
-
-        #endregion Comment
     }
 }

--- a/src/EFCore.PG/Metadata/Internal/NpgsqlAnnotationNames.cs
+++ b/src/EFCore.PG/Metadata/Internal/NpgsqlAnnotationNames.cs
@@ -22,7 +22,6 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.Internal
         public const string DatabaseTemplate = Prefix + "DatabaseTemplate";
         public const string Tablespace = Prefix + "Tablespace";
         public const string StorageParameterPrefix = Prefix + "StorageParameter:";
-        public const string Comment = Prefix + "Comment";
         public const string UnloggedTable = Prefix + "UnloggedTable";
         public const string IdentityOptions = Prefix + "IdentitySequenceOptions";
 
@@ -47,5 +46,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.Internal
 
         [Obsolete("Replaced by ValueGenerationStrategy.SerialColumn")]
         public const string ValueGeneratedOnAdd = Prefix + "ValueGeneratedOnAdd";
+
+        [Obsolete("Replaced by built-in EF Core support, use HasComment on entities or properties.")]
+        public const string Comment = Prefix + "Comment";
     }
 }

--- a/src/EFCore.PG/Migrations/Internal/NpgsqlMigrationsAnnotationProvider.cs
+++ b/src/EFCore.PG/Migrations/Internal/NpgsqlMigrationsAnnotationProvider.cs
@@ -18,8 +18,6 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations.Internal
 
         public override IEnumerable<IAnnotation> For(IEntityType entityType)
         {
-            if (NpgsqlEntityTypeExtensions.GetComment(entityType) is string comment)
-                yield return new Annotation(NpgsqlAnnotationNames.Comment, comment);
             if (entityType.GetIsUnlogged())
                 yield return new Annotation(NpgsqlAnnotationNames.UnloggedTable, entityType.GetIsUnlogged());
             if (entityType[CockroachDbAnnotationNames.InterleaveInParent] != null)
@@ -47,9 +45,6 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations.Internal
                     }
                 }
             }
-
-            if (NpgsqlPropertyExtensions.GetComment(property) is string comment)
-                yield return new Annotation(NpgsqlAnnotationNames.Comment, comment);
         }
 
         public override IEnumerable<IAnnotation> For(IIndex index)

--- a/src/EFCore.PG/Scaffolding/Internal/NpgsqlDatabaseModelFactory.cs
+++ b/src/EFCore.PG/Scaffolding/Internal/NpgsqlDatabaseModelFactory.cs
@@ -222,7 +222,7 @@ WHERE
                     };
 
                     if (reader.GetValueOrDefault<string>("description") is string comment)
-                        table[NpgsqlAnnotationNames.Comment] = comment;
+                        table.Comment = comment;
 
                     tables.Add(table);
                 }
@@ -433,7 +433,7 @@ ORDER BY attnum";
                         }
 
                         if (record.GetValueOrDefault<string>("description") is string comment)
-                            column[NpgsqlAnnotationNames.Comment] = comment;
+                            column.Comment = comment;
 
                         table.Columns.Add(column);
                     }

--- a/test/EFCore.PG.FunctionalTests/NpgsqlMigrationSqlGeneratorTest.cs
+++ b/test/EFCore.PG.FunctionalTests/NpgsqlMigrationSqlGeneratorTest.cs
@@ -268,6 +268,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL
     CHECK (SSN > 0),
     FOREIGN KEY (""EmployerId"") REFERENCES ""Companies"" (""Id"")
 );
+COMMENT ON TABLE dbo.""People"" IS 'Table comment';
+COMMENT ON COLUMN dbo.""People"".""EmployerId"" IS 'Employer ID comment';
 ");
         }
 
@@ -1282,6 +1284,7 @@ ALTER TABLE dbo.""People"" RESET (user_catalog_table);
                 {
                     Name = "People",
                     Schema = "dbo",
+                    Comment = "Some comment",
                     Columns =
                     {
                         new AddColumnOperation
@@ -1295,8 +1298,7 @@ ALTER TABLE dbo.""People"" RESET (user_catalog_table);
                     PrimaryKey = new AddPrimaryKeyOperation
                     {
                         Columns = new[] { "Id" }
-                    },
-                    [NpgsqlAnnotationNames.Comment] = "Some comment",
+                    }
                 });
 
             AssertSql(
@@ -1324,7 +1326,7 @@ COMMENT ON TABLE dbo.""People"" IS 'Some comment';
                             Table = "People",
                             ClrType = typeof(int),
                             IsNullable = false,
-                            [NpgsqlAnnotationNames.Comment] = "Some comment",
+                            Comment = "Some comment"
                         }
                     },
                     PrimaryKey = new AddPrimaryKeyOperation
@@ -1350,8 +1352,8 @@ COMMENT ON COLUMN dbo.""People"".""Id"" IS 'Some comment';
                 {
                     Name = "People",
                     Schema = "dbo",
-                    OldTable = new TableOperation { [NpgsqlAnnotationNames.Comment] = "Old comment" },
-                    [NpgsqlAnnotationNames.Comment] = "New comment"
+                    Comment = "New comment",
+                    OldTable = new TableOperation { Comment = "Old comment" }
                 });
 
             AssertSql(
@@ -1367,7 +1369,7 @@ COMMENT ON COLUMN dbo.""People"".""Id"" IS 'Some comment';
                 {
                     Name = "People",
                     Schema = "dbo",
-                    OldTable = new TableOperation { [NpgsqlAnnotationNames.Comment] = "New comment" }
+                    OldTable = new TableOperation { Comment = "New comment" }
                 });
             AssertSql(
                 @"COMMENT ON TABLE dbo.""People"" IS NULL;
@@ -1385,7 +1387,7 @@ COMMENT ON COLUMN dbo.""People"".""Id"" IS 'Some comment';
                 ClrType = typeof(int),
                 ColumnType = "int",
                 IsNullable = false,
-                [NpgsqlAnnotationNames.Comment] = "Some comment",
+                Comment = "Some comment"
             });
 
             AssertSql(
@@ -1407,8 +1409,8 @@ COMMENT ON COLUMN dbo.""People"".foo IS 'Some comment';
                     ColumnType = "int",
                     IsNullable = false,
                     DefaultValue = 7,
-                    OldColumn = new ColumnOperation { [NpgsqlAnnotationNames.Comment] = "Old comment" },
-                    [NpgsqlAnnotationNames.Comment] = "New comment"
+                    Comment = "New comment",
+                    OldColumn = new ColumnOperation { Comment = "Old comment" }
                 });
 
             AssertSql(
@@ -1432,7 +1434,7 @@ COMMENT ON COLUMN dbo.""People"".""LuckyNumber"" IS 'New comment';
                     ColumnType = "int",
                     IsNullable = false,
                     DefaultValue = 7,
-                    OldColumn = new ColumnOperation { [NpgsqlAnnotationNames.Comment] = "Old comment" }
+                    OldColumn = new ColumnOperation { Comment = "Old comment" }
                 });
 
             AssertSql(

--- a/test/EFCore.PG.FunctionalTests/Scaffolding/NpgsqlDatabaseModelFactoryTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Scaffolding/NpgsqlDatabaseModelFactoryTest.cs
@@ -1694,8 +1694,8 @@ COMMENT ON COLUMN comment.a IS 'column comment'",
                 dbModel =>
                 {
                     var table = dbModel.Tables.Single();
-                    Assert.Equal("table comment", table.FindAnnotation(NpgsqlAnnotationNames.Comment).Value);
-                    Assert.Equal("column comment", table.Columns.Single().FindAnnotation(NpgsqlAnnotationNames.Comment).Value);
+                    Assert.Equal("table comment", table.Comment);
+                    Assert.Equal("column comment", table.Columns.Single().Comment);
                 },
                 "DROP TABLE comment");
 


### PR DESCRIPTION
Unlike the previous attempt in #950, this doesn't exactly conserve backwards compatibility by recognizing the old annotations, so applying old migrations will not generate the comments. However, the previous obsoleted builder methods (ForNpgsqlHasComment) now simply call the new ones, and the first time a migration is generated after upgrading to 3.0.0 the comments will be recreated.

This cleans up the source code, and seems acceptable as this is a rarely-used feature with no functional impact.

Closes #892 
