### PR TITLE
Map JsonDocument and JsonElement

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
 
   <PropertyGroup Label="Package Versions">
     <VersionPrefix>3.0.0</VersionPrefix>
-    <NpgsqlVersion>4.1.0-preview1</NpgsqlVersion>
+    <NpgsqlVersion>4.1.0-ci.2201</NpgsqlVersion>
     <EFCoreVersion>3.0.0-preview9.19421.11</EFCoreVersion>
     <MicrosoftExtensionsVersion>3.0.0-preview9.19421.6</MicrosoftExtensionsVersion>
   </PropertyGroup>

--- a/EFCore.PG.sln.DotSettings
+++ b/EFCore.PG.sln.DotSettings
@@ -124,6 +124,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ownerns/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=pgcrypto/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=plpgsql/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Poco/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=postgis/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=postgre/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=postgresql/@EntryIndexedValue">True</s:Boolean>

--- a/src/EFCore.PG/Extensions/NpgsqlJsonDbFunctionsExtensions.cs
+++ b/src/EFCore.PG/Extensions/NpgsqlJsonDbFunctionsExtensions.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.Extensions
+{
+    /// <summary>
+    /// Provides methods for <see cref="JsonElement"/> supporting translation to PostgreSQL JSON operators and functions.
+    /// </summary>
+    public static class NpgsqlJsonDbFunctionsExtensions
+    {
+        /// <summary>
+        /// Checks if <paramref name="left"/> contains <paramref name="right"/> as top-level entries.
+        /// </summary>
+        public static bool JsonContains(this DbFunctions _, JsonElement left, JsonElement right)
+            => throw ClientEvaluationNotSupportedException();
+
+        /// <summary>
+        /// Checks if <paramref name="left"/> contains <paramref name="right"/> as top-level entries.
+        /// </summary>
+        public static bool JsonContains(this DbFunctions _, JsonElement left, string right)
+            => throw ClientEvaluationNotSupportedException();
+
+        /// <summary>
+        /// Checks if <paramref name="left"/> is contained in <paramref name="right"/> as top-level entries.
+        /// </summary>
+        public static bool JsonContained(this DbFunctions _, JsonElement left, JsonElement right)
+            => throw ClientEvaluationNotSupportedException();
+
+        /// <summary>
+        /// Checks if <paramref name="left"/> is contained in <paramref name="right"/> as top-level entries.
+        /// </summary>
+        public static bool JsonContained(this DbFunctions _, string left, JsonElement right)
+            => throw ClientEvaluationNotSupportedException();
+
+        /// <summary>
+        /// Checks if <paramref name="key"/> exists as a top-level key within <paramref name="element"/>.
+        /// </summary>
+        public static bool JsonExists(this DbFunctions _, JsonElement element, string key)
+            => throw ClientEvaluationNotSupportedException();
+
+        /// <summary>
+        /// Checks if any of the given <paramref name="keys"/> exist as top-level keys within <paramref name="element"/>.
+        /// </summary>
+        public static bool JsonExistAny(this DbFunctions _, JsonElement element, string[] keys)
+            => throw ClientEvaluationNotSupportedException();
+
+        /// <summary>
+        /// Checks if all of the given <paramref name="keys"/> exist as top-level keys within <paramref name="element"/>.
+        /// </summary>
+        public static bool JsonExistAll(this DbFunctions _, JsonElement element, string[] keys)
+            => throw ClientEvaluationNotSupportedException();
+
+        static NotSupportedException ClientEvaluationNotSupportedException([CallerMemberName] string method = default)
+            => new NotSupportedException($"{method} is only intended for use via SQL translation as part of an EF Core LINQ query.");
+    }
+}

--- a/src/EFCore.PG/Extensions/NpgsqlNetworkExtensions.cs
+++ b/src/EFCore.PG/Extensions/NpgsqlNetworkExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Net.NetworkInformation;
 using System.Runtime.CompilerServices;
@@ -1056,7 +1057,6 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns>
         /// A <see cref="NotSupportedException"/>.
         /// </returns>
-        [NotNull]
         static NotSupportedException ClientEvaluationNotSupportedException([CallerMemberName] string method = default)
             => new NotSupportedException($"{method} is only intended for use via SQL translation as part of an EF Core LINQ query.");
 

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlArrayMethodTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlArrayMethodTranslator.cs
@@ -33,12 +33,12 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Inte
         [NotNull]
         readonly NpgsqlSqlExpressionFactory _sqlExpressionFactory;
         [NotNull]
-        readonly NpgsqlJsonTranslator _jsonTranslator;
+        readonly NpgsqlJsonPocoTranslator _jsonPocoTranslator;
 
-        public NpgsqlArrayMethodTranslator(NpgsqlSqlExpressionFactory sqlExpressionFactory, NpgsqlJsonTranslator jsonTranslator)
+        public NpgsqlArrayMethodTranslator(NpgsqlSqlExpressionFactory sqlExpressionFactory, NpgsqlJsonPocoTranslator jsonPocoTranslator)
         {
             _sqlExpressionFactory = sqlExpressionFactory;
-            _jsonTranslator = jsonTranslator;
+            _jsonPocoTranslator = jsonPocoTranslator;
         }
 
         [CanBeNull]
@@ -60,7 +60,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Inte
             {
                 return
                     _sqlExpressionFactory.GreaterThan(
-                        _jsonTranslator.TranslateArrayLength(arrayOperand) ??
+                        _jsonPocoTranslator.TranslateArrayLength(arrayOperand) ??
                         _sqlExpressionFactory.Function("cardinality", arguments, typeof(int?)),
                         _sqlExpressionFactory.Constant(0));
             }

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlJsonDomTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlJsonDomTranslator.cs
@@ -1,0 +1,192 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+using Microsoft.EntityFrameworkCore.Storage;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Extensions;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Query.Expressions.Internal;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Query.Internal;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Internal
+{
+    public class NpgsqlJsonDomTranslator : IMemberTranslator, IMethodCallTranslator
+    {
+        static readonly MemberInfo RootElement = typeof(JsonDocument).GetProperty(nameof(JsonDocument.RootElement));
+        static readonly MethodInfo GetProperty = typeof(JsonElement).GetRuntimeMethod(nameof(JsonElement.GetProperty), new[] { typeof(string) });
+        static readonly MethodInfo GetArrayLength = typeof(JsonElement).GetRuntimeMethod(nameof(JsonElement.GetArrayLength), Type.EmptyTypes);
+
+        static readonly MethodInfo ArrayIndexer = typeof(JsonElement).GetProperties()
+            .Single(p => p.GetIndexParameters().Length == 1 && p.GetIndexParameters()[0].ParameterType == typeof(int))
+            .GetMethod;
+
+        static readonly string[] GetMethods =
+        {
+            nameof(JsonElement.GetBoolean),
+            nameof(JsonElement.GetDateTime),
+            nameof(JsonElement.GetDateTimeOffset),
+            nameof(JsonElement.GetDecimal),
+            nameof(JsonElement.GetDouble),
+            nameof(JsonElement.GetGuid),
+            nameof(JsonElement.GetInt16),
+            nameof(JsonElement.GetInt32),
+            nameof(JsonElement.GetInt64),
+            nameof(JsonElement.GetSingle),
+            nameof(JsonElement.GetString)
+        };
+
+        readonly NpgsqlSqlExpressionFactory _sqlExpressionFactory;
+        readonly RelationalTypeMapping _stringTypeMapping;
+        readonly RelationalTypeMapping _boolTypeMapping;
+        readonly RelationalTypeMapping _jsonbTypeMapping;
+
+        public NpgsqlJsonDomTranslator(NpgsqlSqlExpressionFactory sqlExpressionFactory, IRelationalTypeMappingSource typeMappingSource)
+        {
+            _sqlExpressionFactory = sqlExpressionFactory;
+            _stringTypeMapping = typeMappingSource.FindMapping(typeof(string));
+            _boolTypeMapping = typeMappingSource.FindMapping(typeof(bool));
+            _jsonbTypeMapping = typeMappingSource.FindMapping("jsonb");
+        }
+
+        public SqlExpression Translate(SqlExpression instance, MemberInfo member, Type returnType)
+        {
+            if (member.DeclaringType != typeof(JsonDocument))
+                return null;
+
+            if (member == RootElement &&
+                instance is ColumnExpression column &&
+                column.TypeMapping is NpgsqlJsonTypeMapping)
+            {
+                // Simply get rid of the RootElement member access
+                return column;
+            }
+
+            return null;
+        }
+
+        public SqlExpression Translate(SqlExpression instance, MethodInfo method, IReadOnlyList<SqlExpression> arguments)
+            => TranslateJsonElementMethod(instance, method, arguments) ??
+               TranslateDbFunctionsMethod(method, arguments);
+
+        public SqlExpression TranslateJsonElementMethod(SqlExpression instance, MethodInfo method, IReadOnlyList<SqlExpression> arguments)
+        {
+            if (method.DeclaringType != typeof(JsonElement) ||
+                !(instance.TypeMapping is NpgsqlJsonTypeMapping mapping))
+            {
+                return null;
+            }
+
+            if (method == GetProperty || method == ArrayIndexer)
+            {
+                // The first time we see a JSON traversal it's on a column - create a JsonTraversalExpression.
+                // Traversals on top of that get appended into the same expression.
+                return instance is ColumnExpression columnExpression
+                    ? _sqlExpressionFactory.JsonTraversal(columnExpression, arguments, false, typeof(string), mapping)
+                    : instance is JsonTraversalExpression prevPathTraversal
+                        ? prevPathTraversal.Append(_sqlExpressionFactory.ApplyDefaultTypeMapping(arguments[0]))
+                        : null;
+            }
+
+            if (GetMethods.Contains(method.Name) &&
+                arguments.Count == 0 &&
+                instance is JsonTraversalExpression traversal)
+            {
+                var traversalToText = new JsonTraversalExpression(
+                    traversal.Expression,
+                    traversal.Path,
+                    returnsText: true,
+                    typeof(string),
+                    _stringTypeMapping);
+
+                return method.Name == nameof(JsonElement.GetString)
+                    ? traversalToText
+                    : ConvertFromText(traversalToText, method.ReturnType);
+            }
+
+            if (method == GetArrayLength)
+            {
+                return _sqlExpressionFactory.Function(
+                    mapping.IsJsonb ? "jsonb_array_length" : "json_array_length",
+                    new[] { instance }, typeof(int));
+            }
+
+            if (method.Name.StartsWith("TryGet") && arguments.Count == 0)
+                throw new InvalidOperationException($"The TryGet* methods on {nameof(JsonElement)} aren't translated yet, use Get* instead.'");
+
+            return null;
+        }
+
+        public SqlExpression TranslateDbFunctionsMethod(MethodInfo method, IReadOnlyList<SqlExpression> arguments)
+        {
+            if (arguments.Any(a => a.TypeMapping is NpgsqlJsonTypeMapping jsonMapping && !jsonMapping.IsJsonb))
+                throw new InvalidOperationException("JSON methods on EF.Functions only support the jsonb type, not json.");
+
+            return method.Name switch
+            {
+                nameof(NpgsqlJsonDbFunctionsExtensions.JsonContains) => new SqlCustomBinaryExpression(
+                    _sqlExpressionFactory.ApplyDefaultTypeMapping(arguments[1]),
+                    _sqlExpressionFactory.ApplyDefaultTypeMapping(arguments[2]),
+                    "@>",
+                    typeof(bool),
+                    _boolTypeMapping),
+
+                nameof(NpgsqlJsonDbFunctionsExtensions.JsonContained) => new SqlCustomBinaryExpression(
+                    _sqlExpressionFactory.ApplyDefaultTypeMapping(arguments[1]),
+                    _sqlExpressionFactory.ApplyDefaultTypeMapping(arguments[2]),
+                    "<@",
+                    typeof(bool),
+                    _boolTypeMapping),
+
+                nameof(NpgsqlJsonDbFunctionsExtensions.JsonExists) => new SqlCustomBinaryExpression(
+                    _sqlExpressionFactory.ApplyDefaultTypeMapping(arguments[1]),
+                    _sqlExpressionFactory.ApplyDefaultTypeMapping(arguments[2]),
+                    "?",
+                    typeof(bool),
+                    _boolTypeMapping),
+
+                nameof(NpgsqlJsonDbFunctionsExtensions.JsonExistAny) => new SqlCustomBinaryExpression(
+                    _sqlExpressionFactory.ApplyDefaultTypeMapping(arguments[1]),
+                    _sqlExpressionFactory.ApplyDefaultTypeMapping(arguments[2]),
+                    "?|",
+                    typeof(bool),
+                    _boolTypeMapping),
+
+                nameof(NpgsqlJsonDbFunctionsExtensions.JsonExistAll) => new SqlCustomBinaryExpression(
+                    _sqlExpressionFactory.ApplyDefaultTypeMapping(arguments[1]),
+                    _sqlExpressionFactory.ApplyDefaultTypeMapping(arguments[2]),
+                    "?&",
+                    typeof(bool),
+                    _boolTypeMapping),
+
+                _ => null
+            };
+        }
+
+        // The PostgreSQL traversal operator always returns text, so we need to convert to int, bool, etc.
+        SqlExpression ConvertFromText(SqlExpression expression, Type returnType)
+        {
+            switch (Type.GetTypeCode(returnType))
+            {
+            case TypeCode.Boolean:
+            case TypeCode.Byte:
+            case TypeCode.DateTime:
+            case TypeCode.Decimal:
+            case TypeCode.Double:
+            case TypeCode.Int16:
+            case TypeCode.Int32:
+            case TypeCode.Int64:
+            case TypeCode.SByte:
+            case TypeCode.Single:
+            case TypeCode.UInt16:
+            case TypeCode.UInt32:
+            case TypeCode.UInt64:
+                return _sqlExpressionFactory.Convert(expression, returnType, _sqlExpressionFactory.FindMapping(returnType));
+            default:
+                return expression;
+            }
+        }
+    }
+}

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlMemberTranslatorProvider.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlMemberTranslatorProvider.cs
@@ -1,6 +1,8 @@
 ﻿using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Storage;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Query.Internal;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Internal
 {
@@ -9,21 +11,23 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Inte
     /// </summary>
     public class NpgsqlMemberTranslatorProvider : RelationalMemberTranslatorProvider
     {
-        public NpgsqlJsonTranslator JsonTranslator { get; }
+        public NpgsqlJsonPocoTranslator JsonPocoTranslator { get; }
 
         public NpgsqlMemberTranslatorProvider(
-            [NotNull] RelationalMemberTranslatorProviderDependencies dependencies)
+            [NotNull] RelationalMemberTranslatorProviderDependencies dependencies,
+            IRelationalTypeMappingSource typeMappingSource)
             : base(dependencies)
         {
             var npgsqlSqlExpressionFactory = (NpgsqlSqlExpressionFactory)dependencies.SqlExpressionFactory;
-            JsonTranslator = new NpgsqlJsonTranslator(npgsqlSqlExpressionFactory);
+            JsonPocoTranslator = new NpgsqlJsonPocoTranslator(npgsqlSqlExpressionFactory);
 
             AddTranslators(
                 new IMemberTranslator[] {
                     new NpgsqlStringMemberTranslator(npgsqlSqlExpressionFactory),
                     new NpgsqlDateTimeMemberTranslator(npgsqlSqlExpressionFactory),
                     new NpgsqlRangeTranslator(npgsqlSqlExpressionFactory),
-                    JsonTranslator
+                    new NpgsqlJsonDomTranslator(npgsqlSqlExpressionFactory, typeMappingSource),
+                    JsonPocoTranslator
                 });
         }
     }

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlMethodCallTranslatorProvider.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlMethodCallTranslatorProvider.cs
@@ -15,7 +15,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Inte
         {
             var npgsqlSqlExpressionFactory = (NpgsqlSqlExpressionFactory)dependencies.SqlExpressionFactory;
             var npgsqlTypeMappingSource = (NpgsqlTypeMappingSource)typeMappingSource;
-            var jsonTranslator = new NpgsqlJsonTranslator(npgsqlSqlExpressionFactory);
+            var jsonTranslator = new NpgsqlJsonPocoTranslator(npgsqlSqlExpressionFactory);
 
             AddTranslators(new IMethodCallTranslator[]
             {
@@ -30,7 +30,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Inte
                 new NpgsqlRegexIsMatchTranslator(npgsqlSqlExpressionFactory),
                 new NpgsqlFullTextSearchMethodTranslator(npgsqlSqlExpressionFactory, npgsqlTypeMappingSource),
                 new NpgsqlRangeTranslator(npgsqlSqlExpressionFactory),
-                new NpgsqlNetworkTranslator(npgsqlSqlExpressionFactory, typeMappingSource)
+                new NpgsqlNetworkTranslator(npgsqlSqlExpressionFactory, typeMappingSource),
+                new NpgsqlJsonDomTranslator(npgsqlSqlExpressionFactory, typeMappingSource)
             });
         }
     }

--- a/src/EFCore.PG/Query/Expressions/Internal/JsonTraversalExpression.cs
+++ b/src/EFCore.PG/Query/Expressions/Internal/JsonTraversalExpression.cs
@@ -69,6 +69,15 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.Expressions.Internal
                 ? this
                 : new JsonTraversalExpression(expression, path, ReturnsText, Type, TypeMapping);
 
+        public JsonTraversalExpression Append(SqlExpression pathComponent)
+        {
+            var oldPath = Path;
+            var newPath = new SqlExpression[oldPath.Length + 1];
+            Array.Copy(oldPath, newPath, oldPath.Length);
+            newPath[^1] = pathComponent;
+            return new JsonTraversalExpression(Expression, newPath, ReturnsText, Type,TypeMapping);
+        }
+
         /// <inheritdoc />
         public override bool Equals(object obj) => Equals(obj as JsonTraversalExpression);
 

--- a/src/EFCore.PG/Query/Expressions/Internal/SqlCustomBinaryExpression.cs
+++ b/src/EFCore.PG/Query/Expressions/Internal/SqlCustomBinaryExpression.cs
@@ -46,7 +46,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.Expressions.Internal
             [NotNull] SqlExpression right,
             [NotNull] string binaryOperator,
             [NotNull] Type type,
-            [CanBeNull] RelationalTypeMapping typeMapping)
+            [CanBeNull] RelationalTypeMapping typeMapping = null)
             : base(type, typeMapping)
         {
             Left = Check.NotNull(left, nameof(left));

--- a/src/EFCore.PG/Query/Internal/NpgsqlSqlExpressionFactory.cs
+++ b/src/EFCore.PG/Query/Internal/NpgsqlSqlExpressionFactory.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using Microsoft.EntityFrameworkCore.Query;
@@ -75,6 +77,19 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.Internal
 
         public ILikeExpression ILike(SqlExpression match, SqlExpression pattern, SqlExpression escapeChar = null)
             => (ILikeExpression)ApplyDefaultTypeMapping(new ILikeExpression(match, pattern, escapeChar, null));
+
+        public JsonTraversalExpression JsonTraversal(
+            SqlExpression expression,
+            IEnumerable<SqlExpression> path,
+            bool returnsText,
+            Type type,
+            RelationalTypeMapping typeMapping = null)
+            => new JsonTraversalExpression(
+                ApplyDefaultTypeMapping(expression),
+                path.Select(ApplyDefaultTypeMapping).ToArray(),
+                returnsText,
+                type,
+                typeMapping);
 
         #endregion Expression factory methods
 

--- a/test/EFCore.PG.FunctionalTests/Query/JsonDomQueryTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/JsonDomQueryTest.cs
@@ -1,0 +1,595 @@
+using System;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Linq;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Extensions;
+using Npgsql.EntityFrameworkCore.PostgreSQL.TestUtilities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
+{
+    public class JsonDomQueryTest  : IClassFixture<JsonDomQueryTest.JsonDocumentQueryFixture>
+    {
+        JsonDocumentQueryFixture Fixture { get; }
+
+        public JsonDomQueryTest(JsonDocumentQueryFixture fixture, ITestOutputHelper testOutputHelper)
+        {
+            Fixture = fixture;
+            Fixture.TestSqlLoggerFactory.Clear();
+            Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+        }
+
+        [Fact]
+        public void Roundtrip()
+        {
+            using (var ctx = Fixture.CreateContext())
+            {
+                var jsonb = ctx.JsonbEntities.Single(e => e.Id == 1);
+                PerformAsserts(jsonb.CustomerDocument.RootElement);
+                PerformAsserts(jsonb.CustomerElement);
+
+                var json = ctx.JsonEntities.Single(e => e.Id == 1);
+                PerformAsserts(json.CustomerDocument.RootElement);
+                PerformAsserts(json.CustomerElement);
+            }
+
+            static void PerformAsserts(JsonElement customer)
+            {
+                Assert.Equal("Joe", customer.GetProperty("Name").GetString());
+                Assert.Equal(25, customer.GetProperty("Age").GetInt32());
+                var order1 = customer.GetProperty("Orders")[0];
+                Assert.Equal(99.5m, order1.GetProperty("Price").GetDecimal());
+                Assert.Equal("Some address 1", order1.GetProperty("ShippingAddress").GetString());
+                Assert.Equal(new DateTime(2019, 10, 1), order1.GetProperty("ShippingDate").GetDateTime());
+                var order2 = customer.GetProperty("Orders")[1];
+                Assert.Equal(23, order2.GetProperty("Price").GetDecimal());
+                Assert.Equal("Some address 2", order2.GetProperty("ShippingAddress").GetString());
+                Assert.Equal(new DateTime(2019, 10, 10), order2.GetProperty("ShippingDate").GetDateTime());
+            }
+        }
+
+        [Fact]
+        public void Literal_document()
+        {
+            using (var ctx = Fixture.CreateContext())
+            {
+                Assert.Empty(ctx.JsonbEntities.Where(e => e.CustomerDocument == JsonDocument.Parse(@"
+{ ""Name"": ""Test customer"", ""Age"": 80 }", default)));
+
+                AssertSql(
+                    @"SELECT j.""Id"", j.""CustomerDocument"", j.""CustomerElement""
+FROM ""JsonbEntities"" AS j
+WHERE (j.""CustomerDocument"" = '{""Name"":""Test customer"",""Age"":80}') AND (j.""CustomerDocument"" IS NOT NULL)");
+            }
+        }
+
+        [Fact]
+        public void Parameter_document()
+        {
+            using (var ctx = Fixture.CreateContext())
+            {
+                var expected = ctx.JsonbEntities.Find(1).CustomerDocument;
+                var actual = ctx.JsonbEntities.Single(e => e.CustomerDocument == expected).CustomerDocument;
+                Assert.Equal(actual, expected);
+
+                AssertSql(
+                    @"@__p_0='1'
+
+SELECT j.""Id"", j.""CustomerDocument"", j.""CustomerElement""
+FROM ""JsonbEntities"" AS j
+WHERE (j.""Id"" = @__p_0) AND (@__p_0 IS NOT NULL)
+LIMIT 1",
+                    //
+                    @"@__expected_0='System.Text.Json.JsonDocument' (DbType = Object)
+
+SELECT j.""Id"", j.""CustomerDocument"", j.""CustomerElement""
+FROM ""JsonbEntities"" AS j
+WHERE ((j.""CustomerDocument"" = @__expected_0) AND ((j.""CustomerDocument"" IS NOT NULL) AND (@__expected_0 IS NOT NULL))) OR ((j.""CustomerDocument"" IS NULL) AND (@__expected_0 IS NULL))
+LIMIT 2");
+            }
+        }
+
+        [Fact]
+        public void Parameter_element()
+        {
+            using (var ctx = Fixture.CreateContext())
+            {
+                var expected = ctx.JsonbEntities.Find(1).CustomerElement;
+                var actual = ctx.JsonbEntities.Single(e => e.CustomerElement.Equals(expected)).CustomerElement;
+                Assert.Equal(actual, expected);
+
+                AssertSql(
+                    @"@__p_0='1'
+
+SELECT j.""Id"", j.""CustomerDocument"", j.""CustomerElement""
+FROM ""JsonbEntities"" AS j
+WHERE (j.""Id"" = @__p_0) AND (@__p_0 IS NOT NULL)
+LIMIT 1",
+                    //
+                    @"@__expected_0='{""Age"": 25
+""Name"": ""Joe""
+""IsVip"": false
+""Orders"": [{""Price"": 99.5
+""ShippingDate"": ""2019-10-01""
+""ShippingAddress"": ""Some address 1""}
+{""Price"": 23
+""ShippingDate"": ""2019-10-10""
+""ShippingAddress"": ""Some address 2""}]
+""Statistics"": {""Nested"": {""IntArray"": [3
+4]
+""SomeProperty"": 10}
+""Visits"": 4
+""Purchases"": 3}}' (DbType = Object)
+
+SELECT j.""Id"", j.""CustomerDocument"", j.""CustomerElement""
+FROM ""JsonbEntities"" AS j
+WHERE (j.""CustomerElement"" = @__expected_0) AND (@__expected_0 IS NOT NULL)
+LIMIT 2");
+            }
+        }
+
+        [Fact]
+        public void Text_output_on_document()
+        {
+            using (var ctx = Fixture.CreateContext())
+            {
+                var x = ctx.JsonbEntities.Single(e => e.CustomerDocument.RootElement.GetProperty("Name").GetString() == "Joe");
+                Assert.Equal("Joe", x.CustomerElement.GetProperty("Name").GetString());
+
+                AssertSql(
+                    @"SELECT j.""Id"", j.""CustomerDocument"", j.""CustomerElement""
+FROM ""JsonbEntities"" AS j
+WHERE j.""CustomerDocument""->>'Name' = 'Joe'
+LIMIT 2");
+            }
+        }
+
+        [Fact]
+        public void Text_output()
+        {
+            using (var ctx = Fixture.CreateContext())
+            {
+                var x = ctx.JsonbEntities.Single(e => e.CustomerElement.GetProperty("Name").GetString() == "Joe");
+                Assert.Equal("Joe", x.CustomerElement.GetProperty("Name").GetString());
+
+                AssertSql(
+                    @"SELECT j.""Id"", j.""CustomerDocument"", j.""CustomerElement""
+FROM ""JsonbEntities"" AS j
+WHERE j.""CustomerElement""->>'Name' = 'Joe'
+LIMIT 2");
+            }
+        }
+
+        [Fact]
+        public void Text_output_json()
+        {
+            using (var ctx = Fixture.CreateContext())
+            {
+                var x = ctx.JsonEntities.Single(e => e.CustomerElement.GetProperty("Name").GetString() == "Joe");
+                Assert.Equal("Joe", x.CustomerElement.GetProperty("Name").GetString());
+
+                AssertSql(
+                    @"SELECT j.""Id"", j.""CustomerDocument"", j.""CustomerElement""
+FROM ""JsonEntities"" AS j
+WHERE j.""CustomerElement""->>'Name' = 'Joe'
+LIMIT 2");
+            }
+        }
+
+        [Fact]
+        public void Integer_output()
+        {
+            using (var ctx = Fixture.CreateContext())
+            {
+                var x = ctx.JsonbEntities.Single(e => e.CustomerElement.GetProperty("Age").GetInt32() < 30);
+                Assert.Equal("Joe", x.CustomerElement.GetProperty("Name").GetString());
+
+                AssertSql(
+                    @"SELECT j.""Id"", j.""CustomerDocument"", j.""CustomerElement""
+FROM ""JsonbEntities"" AS j
+WHERE CAST(j.""CustomerElement""->>'Age' AS integer) < 30
+LIMIT 2");
+            }
+        }
+
+        [Fact]
+        public void Bool_output()
+        {
+            using (var ctx = Fixture.CreateContext())
+            {
+                var x = ctx.JsonbEntities.Single(e => e.CustomerElement.GetProperty("IsVip").GetBoolean());
+                Assert.Equal("Moe", x.CustomerElement.GetProperty("Name").GetString());
+
+                AssertSql(
+                    @"SELECT j.""Id"", j.""CustomerDocument"", j.""CustomerElement""
+FROM ""JsonbEntities"" AS j
+WHERE CAST(j.""CustomerElement""->>'IsVip' AS boolean)
+LIMIT 2");
+            }
+        }
+
+        [Fact]
+        public void Nested()
+        {
+            using (var ctx = Fixture.CreateContext())
+            {
+                var x = ctx.JsonbEntities.Single(e => e.CustomerElement.GetProperty("Statistics").GetProperty("Visits").GetInt64() == 4);
+                Assert.Equal("Joe", x.CustomerElement.GetProperty("Name").GetString());
+
+                AssertSql(
+                    @"SELECT j.""Id"", j.""CustomerDocument"", j.""CustomerElement""
+FROM ""JsonbEntities"" AS j
+WHERE CAST(j.""CustomerElement""#>>'{Statistics,Visits}' AS bigint) = 4
+LIMIT 2");
+            }
+        }
+
+        [Fact]
+        public void Nested_twice()
+        {
+            using (var ctx = Fixture.CreateContext())
+            {
+                var x = ctx.JsonbEntities.Single(e => e.CustomerElement.GetProperty("Statistics").GetProperty("Nested").GetProperty("SomeProperty").GetInt32() == 10);
+                Assert.Equal("Joe", x.CustomerElement.GetProperty("Name").GetString());
+
+                AssertSql(
+                    @"SELECT j.""Id"", j.""CustomerDocument"", j.""CustomerElement""
+FROM ""JsonbEntities"" AS j
+WHERE CAST(j.""CustomerElement""#>>'{Statistics,Nested,SomeProperty}' AS integer) = 10
+LIMIT 2");
+            }
+        }
+
+        [Fact]
+        public void Array_of_objects()
+        {
+            using (var ctx = Fixture.CreateContext())
+            {
+                var x = ctx.JsonbEntities.Single(e => e.CustomerElement.GetProperty("Orders")[0].GetProperty("Price").GetDecimal() == 99.5m);
+                Assert.Equal("Joe", x.CustomerElement.GetProperty("Name").GetString());
+
+                AssertSql(
+                    @"SELECT j.""Id"", j.""CustomerDocument"", j.""CustomerElement""
+FROM ""JsonbEntities"" AS j
+WHERE CAST(j.""CustomerElement""#>>'{Orders,0,Price}' AS numeric) = 99.5
+LIMIT 2");
+            }
+        }
+
+        [Fact]
+        public void Array_nested()
+        {
+            using (var ctx = Fixture.CreateContext())
+            {
+                var x = ctx.JsonbEntities.Single(e =>
+                    e.CustomerElement.GetProperty("Statistics").GetProperty("Nested").GetProperty("IntArray")[1].GetInt32() == 4);
+                Assert.Equal("Joe", x.CustomerElement.GetProperty("Name").GetString());
+
+                AssertSql(
+                    @"SELECT j.""Id"", j.""CustomerDocument"", j.""CustomerElement""
+FROM ""JsonbEntities"" AS j
+WHERE CAST(j.""CustomerElement""#>>'{Statistics,Nested,IntArray,1}' AS integer) = 4
+LIMIT 2");
+            }
+        }
+
+        [Fact]
+        public void Array_parameter_index()
+        {
+            using (var ctx = Fixture.CreateContext())
+            {
+                var i = 1;
+                var x = ctx.JsonbEntities.Single(e =>
+                    e.CustomerElement.GetProperty("Statistics").GetProperty("Nested").GetProperty("IntArray")[i].GetInt32() == 4);
+                Assert.Equal("Joe", x.CustomerElement.GetProperty("Name").GetString());
+
+                AssertSql(
+                    @"@__i_0='1'
+
+SELECT j.""Id"", j.""CustomerDocument"", j.""CustomerElement""
+FROM ""JsonbEntities"" AS j
+WHERE (CAST(j.""CustomerElement""#>>ARRAY['Statistics','Nested','IntArray',@__i_0]::TEXT[] AS integer) = 4) AND (CAST(j.""CustomerElement""#>>ARRAY['Statistics','Nested','IntArray',@__i_0]::TEXT[] AS integer) IS NOT NULL)
+LIMIT 2");
+            }
+        }
+
+        [Fact]
+        public void GetArrayLength()
+        {
+            using (var ctx = Fixture.CreateContext())
+            {
+                var x = ctx.JsonbEntities.Single(e => e.CustomerElement.GetProperty("Orders").GetArrayLength() == 2);
+                Assert.Equal("Joe", x.CustomerElement.GetProperty("Name").GetString());
+
+                AssertSql(
+                    @"SELECT j.""Id"", j.""CustomerDocument"", j.""CustomerElement""
+FROM ""JsonbEntities"" AS j
+WHERE jsonb_array_length(j.""CustomerElement""->'Orders') = 2
+LIMIT 2");
+            }
+        }
+
+        [Fact]
+        public void GetArrayLength_json()
+        {
+            using (var ctx = Fixture.CreateContext())
+            {
+                var x = ctx.JsonEntities.Single(e => e.CustomerElement.GetProperty("Orders").GetArrayLength() == 2);
+                Assert.Equal("Joe", x.CustomerElement.GetProperty("Name").GetString());
+
+                AssertSql(
+                    @"SELECT j.""Id"", j.""CustomerDocument"", j.""CustomerElement""
+FROM ""JsonEntities"" AS j
+WHERE json_array_length(j.""CustomerElement""->'Orders') = 2
+LIMIT 2");
+            }
+        }
+
+#if ISSUE_17374
+        [Fact(Skip = "https://github.com/aspnet/EntityFrameworkCore/issues/17374")]
+        public void Array_Any_toplevel()
+        {
+            using (var ctx = Fixture.CreateContext())
+            {
+                var x = ctx.JsonbEntities.Single(e => e.ToplevelArray.Any());
+                Assert.Equal("Joe", x.Customer.Name);
+
+                AssertSql(
+                    @"SELECT j.""Id"", j.""Customer""
+FROM ""JsonbEntities"" AS j
+WHERE jsonb_array_length(j.""ToplevelArray"") > 0
+LIMIT 2");
+            }
+        }
+#endif
+
+        [Fact]
+        public void Like()
+        {
+            using (var ctx = Fixture.CreateContext())
+            {
+                var x = ctx.JsonbEntities.Single(e => e.CustomerElement.GetProperty("Name").GetString().StartsWith("J"));
+                Assert.Equal("Joe", x.CustomerElement.GetProperty("Name").GetString());
+
+                AssertSql(
+                    @"SELECT j.""Id"", j.""CustomerDocument"", j.""CustomerElement""
+FROM ""JsonbEntities"" AS j
+WHERE j.""CustomerElement""->>'Name' LIKE 'J%'
+LIMIT 2");
+            }
+        }
+
+        [Fact]
+        public void JsonContains_with_json_element()
+        {
+            using (var ctx = Fixture.CreateContext())
+            {
+                var element = JsonDocument.Parse(@"{""Name"": ""Joe"", ""Age"": 25}").RootElement;
+                var count = ctx.JsonbEntities.Count(e =>
+                    EF.Functions.JsonContains(e.CustomerElement, element));
+                Assert.Equal(1, count);
+
+                AssertSql(
+                    @"@__element_1='{""Name"": ""Joe""
+""Age"": 25}' (DbType = Object)
+
+SELECT COUNT(*)::INT
+FROM ""JsonbEntities"" AS j
+WHERE (j.""CustomerElement"" @> @__element_1)");
+            }
+        }
+
+        [Fact]
+        public void JsonContains_with_string()
+        {
+            using (var ctx = Fixture.CreateContext())
+            {
+                var count = ctx.JsonbEntities.Count(e =>
+                    EF.Functions.JsonContains(e.CustomerElement, @"{""Name"": ""Joe"", ""Age"": 25}"));
+                Assert.Equal(1, count);
+
+                AssertSql(
+                    @"SELECT COUNT(*)::INT
+FROM ""JsonbEntities"" AS j
+WHERE (j.""CustomerElement"" @> '{""Name"": ""Joe"", ""Age"": 25}')");
+            }
+        }
+
+        [Fact]
+        public void JsonContained_with_json_element()
+        {
+            using (var ctx = Fixture.CreateContext())
+            {
+                var element = JsonDocument.Parse(@"{""Name"": ""Joe"", ""Age"": 25}").RootElement;
+                var count = ctx.JsonbEntities.Count(e =>
+                    EF.Functions.JsonContained(element, e.CustomerElement));
+                Assert.Equal(1, count);
+
+                AssertSql(
+                    @"@__element_1='{""Name"": ""Joe""
+""Age"": 25}' (DbType = Object)
+
+SELECT COUNT(*)::INT
+FROM ""JsonbEntities"" AS j
+WHERE (@__element_1 <@ j.""CustomerElement"")");
+            }
+        }
+
+        [Fact]
+        public void JsonContained_with_string()
+        {
+            using (var ctx = Fixture.CreateContext())
+            {
+                var count = ctx.JsonbEntities.Count(e =>
+                    EF.Functions.JsonContained(@"{""Name"": ""Joe"", ""Age"": 25}", e.CustomerElement));
+                Assert.Equal(1, count);
+
+                AssertSql(
+                    @"SELECT COUNT(*)::INT
+FROM ""JsonbEntities"" AS j
+WHERE ('{""Name"": ""Joe"", ""Age"": 25}' <@ j.""CustomerElement"")");
+            }
+        }
+
+        [Fact]
+        public void JsonExists()
+        {
+            using (var ctx = Fixture.CreateContext())
+            {
+                var count = ctx.JsonbEntities.Count(e =>
+                    EF.Functions.JsonExists(e.CustomerElement.GetProperty("Statistics"), "Visits"));
+                Assert.Equal(2, count);
+
+                AssertSql(
+                    @"SELECT COUNT(*)::INT
+FROM ""JsonbEntities"" AS j
+WHERE (j.""CustomerElement""->'Statistics' ? 'Visits')");
+            }
+        }
+
+        [Fact]
+        public void JsonExistAny()
+        {
+            using (var ctx = Fixture.CreateContext())
+            {
+                var count = ctx.JsonbEntities.Count(e =>
+                    EF.Functions.JsonExistAny(e.CustomerElement.GetProperty("Statistics"), new[] { "foo", "Visits" }));
+                Assert.Equal(2, count);
+
+                AssertSql(
+                    @"SELECT COUNT(*)::INT
+FROM ""JsonbEntities"" AS j
+WHERE (j.""CustomerElement""->'Statistics' ?| ARRAY['foo','Visits']::text[])");
+            }
+        }
+
+        [Fact]
+        public void JsonExistAll()
+        {
+            using (var ctx = Fixture.CreateContext())
+            {
+                var count = ctx.JsonbEntities.Count(e =>
+                    EF.Functions.JsonExistAll(e.CustomerElement.GetProperty("Statistics"), new[] { "foo", "Visits" }));
+                Assert.Equal(0, count);
+
+                AssertSql(
+                    @"SELECT COUNT(*)::INT
+FROM ""JsonbEntities"" AS j
+WHERE (j.""CustomerElement""->'Statistics' ?& ARRAY['foo','Visits']::text[])");
+            }
+        }
+
+        #region Support
+
+        void AssertSql(params string[] expected)
+            => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+
+        public class JsonQueryContext : PoolableDbContext
+        {
+            public DbSet<JsonbEntity> JsonbEntities { get; set; }
+            public DbSet<JsonEntity> JsonEntities { get; set; }
+
+            public JsonQueryContext(DbContextOptions options) : base(options) {}
+
+            public static void Seed(JsonQueryContext context)
+            {
+                var customer1 = CreateCustomer1();
+                var customer2 = CreateCustomer2();
+
+                context.JsonbEntities.AddRange(
+                    new JsonbEntity { Id = 1, CustomerDocument = customer1, CustomerElement = customer1.RootElement},
+                    new JsonbEntity { Id = 2, CustomerDocument = customer2, CustomerElement = customer2.RootElement});
+                context.JsonEntities.AddRange(
+                    new JsonEntity { Id = 1, CustomerDocument = customer1, CustomerElement = customer1.RootElement},
+                    new JsonEntity { Id = 2, CustomerDocument = customer2, CustomerElement = customer2.RootElement});
+                context.SaveChanges();
+
+                static JsonDocument CreateCustomer1() => JsonDocument.Parse(@"
+                {
+                    ""Name"": ""Joe"",
+                    ""Age"": 25,
+                    ""IsVip"": false,
+                    ""Statistics"":
+                    {
+                        ""Visits"": 4,
+                        ""Purchases"": 3,
+                        ""Nested"":
+                        {
+                            ""SomeProperty"": 10,
+                            ""IntArray"": [3, 4]
+                        }
+                    },
+                    ""Orders"":
+                    [
+                        {
+                            ""Price"": 99.5,
+                            ""ShippingAddress"": ""Some address 1"",
+                            ""ShippingDate"": ""2019-10-01""
+                        },
+                        {
+                            ""Price"": 23,
+                            ""ShippingAddress"": ""Some address 2"",
+                            ""ShippingDate"": ""2019-10-10""
+                        }
+                    ]
+                }");
+
+                static JsonDocument CreateCustomer2() => JsonDocument.Parse(@"
+                {
+                    ""Name"": ""Moe"",
+                    ""Age"": 35,
+                    ""IsVip"": true,
+                    ""Statistics"":
+                    {
+                        ""Visits"": 20,
+                        ""Purchases"": 25,
+                        ""Nested"":
+                        {
+                            ""SomeProperty"": 20,
+                            ""IntArray"": [5, 6]
+                        }
+                    },
+                    ""Orders"":
+                    [
+                        {
+                            ""Price"": 5,
+                            ""ShippingAddress"": ""Moe's address"",
+                            ""ShippingDate"": ""2019-11-03""
+                        }
+                    ]
+                }");
+            }
+        }
+
+        public class JsonbEntity
+        {
+            public int Id { get; set; }
+
+            public JsonDocument CustomerDocument { get; set; }
+            public JsonElement CustomerElement { get; set; }
+        }
+
+        public class JsonEntity
+        {
+            public int Id { get; set; }
+
+            [Column(TypeName = "json")]
+            public JsonDocument CustomerDocument { get; set; }
+            [Column(TypeName = "json")]
+            public JsonElement CustomerElement { get; set; }
+        }
+
+        public class JsonDocumentQueryFixture : SharedStoreFixtureBase<JsonQueryContext>
+        {
+            protected override string StoreName => "JsonDomQueryTest";
+            protected override ITestStoreFactory TestStoreFactory => NpgsqlTestStoreFactory.Instance;
+            public TestSqlLoggerFactory TestSqlLoggerFactory => (TestSqlLoggerFactory)ListLoggerFactory;
+            protected override void Seed(JsonQueryContext context) => JsonQueryContext.Seed(context);
+        }
+
+        #endregion
+    }
+}

--- a/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingTest.cs
+++ b/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingTest.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.NetworkInformation;
+using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -461,6 +462,38 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage
                              @"{""Price"":99.5,""ShippingAddress"":""Some address 1"",""ShippingDate"":""2019-10-01T00:00:00""}," +
                              @"{""Price"":23,""ShippingAddress"":""Some address 2"",""ShippingDate"":""2019-10-10T00:00:00""}" +
                          @"]}'", literal);
+        }
+
+        [Fact]
+        public void GenerateSqlLiteral_returns_jsonb_document_literal()
+        {
+            var json = @"{""Name"":""Joe"",""Age"":25}";
+            var literal = Mapper.FindMapping(typeof(JsonDocument), "jsonb").GenerateSqlLiteral(JsonDocument.Parse(json));
+            Assert.Equal($"'{json}'", literal);
+        }
+
+        [Fact]
+        public void GenerateSqlLiteral_returns_json_document_literal()
+        {
+            var json = @"{""Name"":""Joe"",""Age"":25}";
+            var literal = Mapper.FindMapping(typeof(JsonDocument), "json").GenerateSqlLiteral(JsonDocument.Parse(json));
+            Assert.Equal($"'{json}'", literal);
+        }
+
+        [Fact]
+        public void GenerateSqlLiteral_returns_jsonb_element_literal()
+        {
+            var json = @"{""Name"":""Joe"",""Age"":25}";
+            var literal = Mapper.FindMapping(typeof(JsonElement), "jsonb").GenerateSqlLiteral(JsonDocument.Parse(json).RootElement);
+            Assert.Equal($"'{json}'", literal);
+        }
+
+        [Fact]
+        public void GenerateSqlLiteral_returns_json_element_literal()
+        {
+            var json = @"{""Name"":""Joe"",""Age"":25}";
+            var literal = Mapper.FindMapping(typeof(JsonElement), "json").GenerateSqlLiteral(JsonDocument.Parse(json).RootElement);
+            Assert.Equal($"'{json}'", literal);
         }
 
         static readonly Customer SampleCustomer = new Customer


### PR DESCRIPTION
Issue #981 enabled mapping arbitrary user POCOs to PG JON. This adds support for mapping the System.Text.Json DOM types JsonDocument and JsonElement, which are more relevant for unstructured scenarios. Traversal is implemented as well as some of the PG JSON operators.

One possible thing to "cast" strongly-typed POCOs as weakly-typed DOM types for the purposes of expressing [various JSON operations](https://www.postgresql.org/docs/current/functions-json.html), including [PG 12's upcoming support for jsonpath](https://www.postgresql.org/docs/12/functions-json.html).

Closes #1002

/cc @smitpatel @ajcvickers @divega @AndriySvyryd @maurycy @bricelam

Note: pushed the PR just before leaving so there may be some silliness (will go over it again tomorrow).