### PR TITLE
Substring without length translation

### DIFF
--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlStringMethodTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlStringMethodTranslator.cs
@@ -41,7 +41,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Inte
         [NotNull] static readonly MethodInfo TrimBothWithNoParam = typeof(string).GetRuntimeMethod(nameof(string.Trim), Type.EmptyTypes);
         [NotNull] static readonly MethodInfo TrimBothWithChars = typeof(string).GetRuntimeMethod(nameof(string.Trim), new[] { typeof(char[]) });
         [NotNull] static readonly MethodInfo TrimBothWithSingleChar = typeof(string).GetRuntimeMethod(nameof(string.Trim), new[] { typeof(char) });
-        [NotNull] static readonly MethodInfo Substring = typeof(string).GetTypeInfo().GetDeclaredMethods(nameof(string.Substring)).Single(m => m.GetParameters().Length == 2);
+        [NotNull] static readonly MethodInfo Substring = typeof(string).GetTypeInfo().GetDeclaredMethods(nameof(string.Substring)).Single(m => m.GetParameters().Length == 1);
+        [NotNull] static readonly MethodInfo SubstringWithLength = typeof(string).GetTypeInfo().GetDeclaredMethods(nameof(string.Substring)).Single(m => m.GetParameters().Length == 2);
         [NotNull] static readonly MethodInfo Replace = typeof(string).GetRuntimeMethod(nameof(string.Replace), new[] { typeof(string), typeof(string) });
         [NotNull] static readonly MethodInfo PadLeft = typeof(string).GetRuntimeMethod(nameof(string.PadLeft), new[] { typeof(int) });
         [NotNull] static readonly MethodInfo PadLeftWithChar = typeof(string).GetRuntimeMethod(nameof(string.PadLeft), new[] { typeof(int), typeof(char) });
@@ -106,16 +107,15 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Inte
                     instance.TypeMapping);
             }
 
-            if (method == Substring)
+            if (method == Substring || method == SubstringWithLength)
             {
+                var args =
+                    method == Substring
+                        ? new[] { instance, GenerateOneBasedIndexExpression(arguments[0]) }
+                        : new[] { instance, GenerateOneBasedIndexExpression(arguments[0]), arguments[1] };
                 return _sqlExpressionFactory.Function(
                     "SUBSTRING",
-                    new[]
-                    {
-                        instance,
-                        GenerateOneBasedIndexExpression(arguments[0]),
-                        arguments[1]
-                    },
+                    args,
                     method.ReturnType,
                     instance.TypeMapping);
             }

--- a/test/EFCore.PG.FunctionalTests/Query/SimpleQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/SimpleQueryNpgsqlTest.cs
@@ -172,6 +172,35 @@ WHERE e.""EmployeeID"" IN (0)");
 
         #endregion
 
+        #region Substring
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public Task Substring_without_length_with_Index_of(bool isAsync)
+            => AssertQuery<Customer>(isAsync, cs => cs
+                .Where(x => x.Address == "Walserweg 21")
+                .Where(x => x.Address.Substring(x.Address.IndexOf("e")) == "erweg 21"), entryCount: 1);
+
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public Task Substring_without_length_with_constant(bool isAsync)
+            => AssertQuery<Customer>(isAsync, cs => cs
+                //Walserweg 21
+                .Where(x => x.Address.Substring(5) == "rweg 21"), entryCount: 1);
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public Task Substring_without_length_with_closure(bool isAsync)
+        {
+            var startIndex = 5;
+            return AssertQuery<Customer>(isAsync, cs => cs
+                //Walserweg 21
+                .Where(x => x.Address.Substring(startIndex) == "rweg 21"), entryCount: 1);
+        }
+
+        #endregion
+
         #region Array contains
 
         // Note that this also takes care of array.Any(x => x == y)


### PR DESCRIPTION
dotnet `string.Substring` has overload with one parameter, and postgres `SUBSTRING` has semantic equivalent arguments (optional length)