### PR TITLE
Add support for PGroonga.EntityFrameworkCore EF.Functions

### DIFF
--- a/src/EFCore.PG/Query/Internal/NpgsqlEvaluatableExpressionFilter.cs
+++ b/src/EFCore.PG/Query/Internal/NpgsqlEvaluatableExpressionFilter.cs
@@ -45,6 +45,13 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.Internal
                 return false;
             }
 
+            // PGroonga
+            if (expression is MethodCallExpression exp &&
+                    exp.Method.DeclaringType?.FullName == "Microsoft.EntityFrameworkCore.PGroongaDbFunctionsExtensions")
+            {
+                return false;
+            }
+
             return base.IsEvaluatableExpression(expression, model);
         }
     }


### PR DESCRIPTION
Unfortunately, it seems a filter is still required to run DbFunctions on ef core 3.0.