### PR TITLE
Update repository and project urls

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,12 +6,12 @@
     <VersionPrefix>3.1.0</VersionPrefix>
 
     <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>git://github.com/npgsql/npgsql</RepositoryUrl>
+    <RepositoryUrl>git://github.com/npgsql/Npgsql.EntityFrameworkCore.PostgreSQL</RepositoryUrl>
 
     <TargetFrameworks>netstandard2.1</TargetFrameworks>
 
     <PackageLicenseExpression>PostgreSQL</PackageLicenseExpression>
-    <PackageProjectUrl>https://www.npgsql.org</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/npgsql/Npgsql.EntityFrameworkCore.PostgreSQL</PackageProjectUrl>
     <PackageIcon>postgresql.png</PackageIcon>
   </PropertyGroup>
 


### PR DESCRIPTION
Per the [GPR docs](https://help.github.com/en/articles/configuring-nuget-for-use-with-github-package-registry#publishing-multiple-packages-to-the-same-github-repository), we need these fields to point at the correct repo.

I think this is why some CI packages for `Npgsql.EntityFrameworkCore.PostgreSQL` are showing up here https://github.com/npgsql/npgsql/packages instead of here https://github.com/npgsql/Npgsql.EntityFrameworkCore.PostgreSQL/packages.

I've submitted a support ticket to GitHub asking how to delete/move/update the packages that are in the wrong place. I'll let you guys know when I hear back from them.