### PR TITLE
Update target framework to 2.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/npgsql/Npgsql.EntityFrameworkCore.PostgreSQL</RepositoryUrl>
 
-    <TargetFrameworks>netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.2</TargetFrameworks>
 
     <PackageLicenseExpression>PostgreSQL</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/npgsql/Npgsql.EntityFrameworkCore.PostgreSQL</PackageProjectUrl>


### PR DESCRIPTION
When trying to use 3.0.1 in my project (i was using 2.2.4 previously), I get this error:

`MyApp.csproj: [NU1202] Package Npgsql.EntityFrameworkCore.PostgreSQL 3.0.1 is not compatible with netcoreapp2.2 (.NETCoreApp,Version=v2.2). Package Npgsql.EntityFrameworkCore.PostgreSQL 3.0.1 supports: netstandard2.1 (.NETStandard,Version=v2.1)`

I am using dotnet core 2.2.401 on macOS